### PR TITLE
トップページに掲載団体セクションを静的生成する

### DIFF
--- a/data/organizations.json
+++ b/data/organizations.json
@@ -8,7 +8,8 @@
     "scraper_type": "kent",
     "scraper_enabled": true,
     "event_type": "open_keiko",
-    "notes": "公式サイトのSCHEDULEから取得"
+    "notes": "公式サイトのSCHEDULEから取得",
+    "public_description": "東京都内で活動する社会人剣道サークルkentの稽古予定を掲載しています。"
   },
   {
     "organization_id": "kenkyukai",
@@ -19,7 +20,8 @@
     "scraper_type": "kenkyukai",
     "scraper_enabled": true,
     "event_type": "open_keiko",
-    "notes": "公式サイトの新着情報から取得"
+    "notes": "公式サイトの新着情報から取得",
+    "public_description": "剣究会が東京都内で開催する剣道稽古会の予定を掲載しています。"
   },
   {
     "organization_id": "kenbokukai",
@@ -30,7 +32,8 @@
     "scraper_type": "kenbokukai",
     "scraper_enabled": true,
     "event_type": "open_keiko",
-    "notes": "公式サイトの稽古会情報記事から取得"
+    "notes": "公式サイトの稽古会情報記事から取得",
+    "public_description": "剣睦会の公式サイトで案内されている剣道稽古会の予定を掲載しています。"
   },
   {
     "organization_id": "ajkf",
@@ -41,7 +44,8 @@
     "scraper_type": "ajkf",
     "scraper_enabled": true,
     "event_type": "federation_keiko",
-    "notes": "全剣連の稽古会一覧・個別行事ページから取得"
+    "notes": "全剣連の稽古会一覧・個別行事ページから取得",
+    "public_description": "全日本剣道連盟が全国各地で開催する公式稽古会の予定を掲載しています。"
   },
   {
     "organization_id": "tokyo",
@@ -52,6 +56,7 @@
     "scraper_type": "tokyo",
     "scraper_enabled": true,
     "event_type": "federation_keiko",
-    "notes": "公式の剣道稽古会・合同稽古会日程PDFから大武道場の合同稽古会を取得"
+    "notes": "公式の剣道稽古会・合同稽古会日程PDFから大武道場の合同稽古会を取得",
+    "public_description": "東京都剣道連盟が東京武道館で開催する剣道合同稽古会の予定を掲載しています。"
   }
 ]

--- a/kendo_keiko/models.py
+++ b/kendo_keiko/models.py
@@ -15,6 +15,7 @@ class Organization:
     scraper_enabled: bool
     event_type: str
     notes: Optional[str] = None
+    public_description: Optional[str] = None
 
 
 @dataclass(frozen=True)

--- a/public/index.html
+++ b/public/index.html
@@ -154,6 +154,57 @@
       font-size: 0.98rem;
     }
 
+    .organization-section {
+      margin: 36px 0 0;
+      padding-top: 20px;
+      border-top: 1px solid var(--border);
+    }
+
+    .organization-section h2 {
+      margin: 0 0 6px;
+      font-size: 18px;
+    }
+
+    .organization-intro {
+      margin: 0 0 12px;
+      color: var(--muted);
+      font-size: 14px;
+    }
+
+    .organization-list {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 4px 18px;
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .organization-item {
+      padding: 8px 0 10px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .organization-item h3 {
+      margin: 0 0 2px;
+      font-size: 15px;
+    }
+
+    .organization-item p {
+      margin: 2px 0;
+      font-size: 13px;
+    }
+
+    .organization-area,
+    .organization-source-note {
+      color: var(--muted);
+      font-size: 12px;
+    }
+
+    .organization-link {
+      font-size: 13px;
+    }
+
   </style>
   <meta name="description" content="関東を中心に、一般参加できる剣道のオープン稽古会・合同稽古会情報を日付順で掲載。東京・埼玉・神奈川・千葉などの稽古先探しにご活用ください。">
   <link rel="canonical" href="https://kendo-keiko.com/">
@@ -176,6 +227,8 @@
   </header>
 
   <main>
+
+
     <div class="toolbar">
       <input id="keyword" type="search" placeholder="団体名・会場・タイトルで検索">
       <select id="organization">
@@ -185,6 +238,50 @@
 
     <div class="count" id="count"></div>
     <div class="cards" id="cards"></div>
+
+    <!-- ORGANIZATION_SECTION_START -->
+    <section class="organization-section" id="listed-organizations" aria-labelledby="listed-organizations-heading">
+      <h2 id="listed-organizations-heading">掲載中の剣道団体・剣道連盟</h2>
+      <p class="organization-intro">
+        各団体・連盟の公式情報をもとに、一般参加できる稽古会や合同稽古会の予定を掲載しています。
+      </p>
+      <ul class="organization-list">
+        <li class="organization-item">
+          <h3>社会人剣道サークルkent</h3>
+          <p class="organization-area">主な地域: 東京都</p>
+          <p>東京都内で活動する社会人剣道サークルkentの稽古予定を掲載しています。</p>
+          <p class="organization-link"><a href="https://kendonetwork.com/" target="_blank" rel="noopener noreferrer">公式サイトを確認</a></p>
+        </li>
+        <li class="organization-item">
+          <h3>剣究会</h3>
+          <p class="organization-area">主な地域: 東京都</p>
+          <p>剣究会が東京都内で開催する剣道稽古会の予定を掲載しています。</p>
+          <p class="organization-link"><a href="https://kenkyukai-kendo.com/" target="_blank" rel="noopener noreferrer">公式サイトを確認</a></p>
+        </li>
+        <li class="organization-item">
+          <h3>剣睦会</h3>
+          <p class="organization-area">主な地域: 東京都</p>
+          <p>剣睦会の公式サイトで案内されている剣道稽古会の予定を掲載しています。</p>
+          <p class="organization-link"><a href="https://kenbokukai.com/" target="_blank" rel="noopener noreferrer">公式サイトを確認</a></p>
+        </li>
+        <li class="organization-item">
+          <h3>全日本剣道連盟</h3>
+          <p class="organization-area">主な地域: 全国</p>
+          <p>全日本剣道連盟が全国各地で開催する公式稽古会の予定を掲載しています。</p>
+          <p class="organization-link"><a href="https://www.kendo.or.jp/event_cat/keiko-kai/" target="_blank" rel="noopener noreferrer">公式サイトを確認</a></p>
+        </li>
+        <li class="organization-item">
+          <h3>東京都剣道連盟</h3>
+          <p class="organization-area">主な地域: 東京都</p>
+          <p>東京都剣道連盟が東京武道館で開催する剣道合同稽古会の予定を掲載しています。</p>
+          <p class="organization-link"><a href="https://www.tokyo-kendo.or.jp/keiko/keikokai-index.html" target="_blank" rel="noopener noreferrer">公式サイトを確認</a></p>
+        </li>
+      </ul>
+      <p class="organization-source-note">
+        日程や参加条件が変更される場合があります。参加前に必ず主催団体の公式情報をご確認ください。
+      </p>
+    </section>
+    <!-- ORGANIZATION_SECTION_END -->
   </main>
 
   <footer>

--- a/scripts/generate_organization_section.py
+++ b/scripts/generate_organization_section.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import argparse
+import json
+from html import escape
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+
+START_MARKER = "<!-- ORGANIZATION_SECTION_START -->"
+END_MARKER = "<!-- ORGANIZATION_SECTION_END -->"
+
+
+def safe_http_url(value: object) -> str:
+    if not value:
+        return ""
+
+    url = str(value).strip()
+    parsed = urlparse(url)
+
+    if parsed.scheme not in {"http", "https"}:
+        return ""
+
+    if not parsed.netloc:
+        return ""
+
+    return url
+
+
+def build_organization_section(
+    organizations: list[dict[str, Any]],
+) -> str:
+    items: list[str] = []
+
+    for organization in organizations:
+        if not organization.get("scraper_enabled", False):
+            continue
+
+        description = str(
+            organization.get("public_description") or ""
+        ).strip()
+
+        if not description:
+            continue
+
+        name = escape(
+            str(organization.get("name") or ""),
+            quote=True,
+        )
+        area = escape(
+            str(organization.get("area") or "地域未設定"),
+            quote=True,
+        )
+        description_html = escape(
+            description,
+            quote=True,
+        )
+
+        website_url = safe_http_url(
+            organization.get("website_url")
+        )
+
+        if website_url:
+            website_html = (
+                '          <p class="organization-link">'
+                f'<a href="{escape(website_url, quote=True)}" '
+                'target="_blank" rel="noopener noreferrer">'
+                "公式サイトを確認"
+                "</a></p>"
+            )
+        else:
+            website_html = ""
+
+        lines = [
+            '        <li class="organization-item">',
+            f"          <h3>{name}</h3>",
+            (
+                '          <p class="organization-area">'
+                f"主な地域: {area}</p>"
+            ),
+            f"          <p>{description_html}</p>",
+        ]
+
+        if website_html:
+            lines.append(website_html)
+
+        lines.append("        </li>")
+        items.append("\n".join(lines))
+
+    if items:
+        body = "\n".join(items)
+    else:
+        body = (
+            '        <li class="organization-item">'
+            "現在掲載中の団体はありません。"
+            "</li>"
+        )
+
+    return "\n".join(
+        [
+            (
+                '    <section class="organization-section" '
+                'id="listed-organizations" '
+                'aria-labelledby="listed-organizations-heading">'
+            ),
+            (
+                '      <h2 id="listed-organizations-heading">'
+                "掲載中の剣道団体・剣道連盟"
+                "</h2>"
+            ),
+            '      <p class="organization-intro">',
+            (
+                "        各団体・連盟の公式情報をもとに、"
+                "一般参加できる稽古会や合同稽古会の予定を"
+                "掲載しています。"
+            ),
+            "      </p>",
+            '      <ul class="organization-list">',
+            body,
+            "      </ul>",
+            '      <p class="organization-source-note">',
+            (
+                "        日程や参加条件が変更される場合があります。"
+                "参加前に必ず主催団体の公式情報をご確認ください。"
+            ),
+            "      </p>",
+            "    </section>",
+        ]
+    )
+
+
+def replace_organization_section(
+    html: str,
+    section: str,
+) -> str:
+    start_index = html.find(START_MARKER)
+    end_index = html.find(END_MARKER)
+
+    if start_index == -1:
+        raise ValueError(
+            f"開始マーカーが見つかりません: {START_MARKER}"
+        )
+
+    if end_index == -1:
+        raise ValueError(
+            f"終了マーカーが見つかりません: {END_MARKER}"
+        )
+
+    if end_index <= start_index:
+        raise ValueError(
+            "団体セクションのマーカー順序が不正です"
+        )
+
+    content_start = start_index + len(START_MARKER)
+
+    return (
+        html[:content_start]
+        + "\n"
+        + section.rstrip()
+        + "\n    "
+        + html[end_index:]
+    )
+
+
+def generate_index(
+    organizations_path: Path,
+    index_path: Path,
+) -> None:
+    organizations = json.loads(
+        organizations_path.read_text(encoding="utf-8")
+    )
+
+    if not isinstance(organizations, list):
+        raise ValueError(
+            "organizations.jsonのトップレベルは配列が必要です"
+        )
+
+    current_html = index_path.read_text(encoding="utf-8")
+    section = build_organization_section(organizations)
+    generated_html = replace_organization_section(
+        current_html,
+        section,
+    )
+
+    index_path.write_text(
+        generated_html,
+        encoding="utf-8",
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "organizations.jsonからトップページの"
+            "掲載団体セクションを生成します"
+        )
+    )
+    parser.add_argument(
+        "--organizations",
+        type=Path,
+        default=Path("data/organizations.json"),
+    )
+    parser.add_argument(
+        "--index",
+        type=Path,
+        default=Path("public/index.html"),
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    generate_index(
+        organizations_path=args.organizations,
+        index_path=args.index,
+    )
+
+    print(
+        "[INFO] organization section generated:",
+        args.index,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_generate_organization_section.py
+++ b/tests/test_generate_organization_section.py
@@ -1,0 +1,156 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.generate_organization_section import (
+    build_organization_section,
+    generate_index,
+    replace_organization_section,
+)
+
+
+class GenerateOrganizationSectionTests(unittest.TestCase):
+    def test_filters_disabled_and_escapes_html(self) -> None:
+        organizations = [
+            {
+                "organization_id": "enabled",
+                "name": '有効団体 <script>"test"</script>',
+                "area": "東京 & 埼玉",
+                "website_url": "https://example.com/?a=1&b=2",
+                "scraper_enabled": True,
+                "public_description": (
+                    "説明 <strong>太字</strong>"
+                ),
+            },
+            {
+                "organization_id": "disabled",
+                "name": "無効団体",
+                "area": "東京都",
+                "website_url": "https://example.net/",
+                "scraper_enabled": False,
+                "public_description": "表示されない説明",
+            },
+        ]
+
+        section = build_organization_section(
+            organizations
+        )
+
+        self.assertIn(
+            "&lt;script&gt;&quot;test&quot;"
+            "&lt;/script&gt;",
+            section,
+        )
+        self.assertIn(
+            "東京 &amp; 埼玉",
+            section,
+        )
+        self.assertIn(
+            "説明 &lt;strong&gt;太字&lt;/strong&gt;",
+            section,
+        )
+        self.assertIn(
+            "https://example.com/?a=1&amp;b=2",
+            section,
+        )
+        self.assertNotIn(
+            "無効団体",
+            section,
+        )
+
+    def test_replace_is_idempotent(self) -> None:
+        template = """<!doctype html>
+<html>
+<body>
+<!-- ORGANIZATION_SECTION_START -->
+old content
+<!-- ORGANIZATION_SECTION_END -->
+<div id="cards"></div>
+</body>
+</html>
+"""
+
+        section = """    <section id="listed-organizations">
+      test
+    </section>"""
+
+        first = replace_organization_section(
+            template,
+            section,
+        )
+        second = replace_organization_section(
+            first,
+            section,
+        )
+
+        self.assertEqual(first, second)
+        self.assertIn(
+            '<div id="cards"></div>',
+            second,
+        )
+
+    def test_generates_index_from_json(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+
+            organizations_path = (
+                root / "organizations.json"
+            )
+            index_path = root / "index.html"
+
+            organizations_path.write_text(
+                json.dumps(
+                    [
+                        {
+                            "name": "東京都剣道連盟",
+                            "area": "東京都",
+                            "website_url": (
+                                "https://example.com/"
+                            ),
+                            "scraper_enabled": True,
+                            "public_description": (
+                                "合同稽古会を掲載しています。"
+                            ),
+                        }
+                    ],
+                    ensure_ascii=False,
+                ),
+                encoding="utf-8",
+            )
+
+            index_path.write_text(
+                """<main>
+<!-- ORGANIZATION_SECTION_START -->
+<!-- ORGANIZATION_SECTION_END -->
+<div id="cards"></div>
+</main>
+""",
+                encoding="utf-8",
+            )
+
+            generate_index(
+                organizations_path,
+                index_path,
+            )
+
+            result = index_path.read_text(
+                encoding="utf-8"
+            )
+
+            self.assertIn(
+                "東京都剣道連盟",
+                result,
+            )
+            self.assertIn(
+                "合同稽古会を掲載しています。",
+                result,
+            )
+            self.assertIn(
+                '<div id="cards"></div>',
+                result,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要

トップページの初期HTMLに掲載団体情報を追加しました。

## 変更内容

- 掲載団体セクションをイベント一覧の下に追加
- 団体マスタから静的HTMLを生成
- 無効団体を除外
- HTMLエスケープ対応
- 生成処理の冪等性を確認
- 既存JavaScriptのイベント描画処理は変更なし

## テスト

- 23 tests OK
- 再生成前後でindex.htmlのSHA-256一致

Closes #14