### PR TITLE
トップページを剣道らしいレスポンシブデザインへ刷新する

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,208 +4,6 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>剣道オープン稽古会一覧｜関東の合同稽古会情報</title>
-  <style>
-    :root {
-      color-scheme: light dark;
-      --bg: #f7f7f8;
-      --card: #ffffff;
-      --text: #1f2937;
-      --muted: #6b7280;
-      --border: #e5e7eb;
-      --accent: #1f6feb;
-    }
-
-    @media (prefers-color-scheme: dark) {
-      :root {
-        --bg: #111827;
-        --card: #1f2937;
-        --text: #f9fafb;
-        --muted: #9ca3af;
-        --border: #374151;
-        --accent: #60a5fa;
-      }
-    }
-
-    body {
-      margin: 0;
-      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-      background: var(--bg);
-      color: var(--text);
-      line-height: 1.6;
-    }
-
-    header {
-      padding: 32px 20px 16px;
-      max-width: 1080px;
-      margin: 0 auto;
-    }
-
-    h1 {
-      margin: 0 0 8px;
-      font-size: 28px;
-    }
-
-    .meta {
-      color: var(--muted);
-      font-size: 14px;
-    }
-
-    main {
-      max-width: 1080px;
-      margin: 0 auto;
-      padding: 0 20px 40px;
-    }
-
-    .toolbar {
-      display: grid;
-      grid-template-columns: 1fr 180px;
-      gap: 12px;
-      margin: 20px 0;
-    }
-
-    @media (max-width: 720px) {
-      .toolbar {
-        grid-template-columns: 1fr;
-      }
-    }
-
-    input, select {
-      padding: 10px 12px;
-      border: 1px solid var(--border);
-      border-radius: 10px;
-      background: var(--card);
-      color: var(--text);
-      font-size: 15px;
-    }
-
-    .count {
-      color: var(--muted);
-      margin-bottom: 12px;
-      font-size: 14px;
-    }
-
-    .cards {
-      display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(310px, 1fr));
-      gap: 14px;
-    }
-
-    .card {
-      background: var(--card);
-      border: 1px solid var(--border);
-      border-radius: 16px;
-      padding: 16px;
-      box-shadow: 0 1px 2px rgba(0,0,0,.04);
-    }
-
-    .date {
-      font-weight: 700;
-      font-size: 18px;
-      margin-bottom: 4px;
-    }
-
-    .org {
-      color: var(--accent);
-      font-weight: 700;
-      margin-bottom: 8px;
-    }
-
-    .title {
-      font-weight: 600;
-      margin-bottom: 8px;
-    }
-
-    .row {
-      margin: 4px 0;
-    }
-
-    .label {
-      color: var(--muted);
-      font-size: 13px;
-      display: inline-block;
-      min-width: 64px;
-    }
-
-    a {
-      color: var(--accent);
-      word-break: break-all;
-    }
-
-    .empty, .error {
-      background: var(--card);
-      border: 1px solid var(--border);
-      border-radius: 16px;
-      padding: 20px;
-    }
-
-    footer {
-      max-width: 1080px;
-      margin: 0 auto;
-      padding: 0 20px 40px;
-      color: var(--muted);
-      font-size: 13px;
-    }
-  
-    .lead {
-      max-width: 900px;
-      margin: 8px 0 28px;
-      color: #cbd5e1;
-      line-height: 1.8;
-      font-size: 0.98rem;
-    }
-
-    .organization-section {
-      margin: 36px 0 0;
-      padding-top: 20px;
-      border-top: 1px solid var(--border);
-    }
-
-    .organization-section h2 {
-      margin: 0 0 6px;
-      font-size: 18px;
-    }
-
-    .organization-intro {
-      margin: 0 0 12px;
-      color: var(--muted);
-      font-size: 14px;
-    }
-
-    .organization-list {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-      gap: 4px 18px;
-      margin: 0;
-      padding: 0;
-      list-style: none;
-    }
-
-    .organization-item {
-      padding: 8px 0 10px;
-      border-bottom: 1px solid var(--border);
-    }
-
-    .organization-item h3 {
-      margin: 0 0 2px;
-      font-size: 15px;
-    }
-
-    .organization-item p {
-      margin: 2px 0;
-      font-size: 13px;
-    }
-
-    .organization-area,
-    .organization-source-note {
-      color: var(--muted);
-      font-size: 12px;
-    }
-
-    .organization-link {
-      font-size: 13px;
-    }
-
-  </style>
   <meta name="description" content="関東を中心に、一般参加できる剣道のオープン稽古会・合同稽古会情報を日付順で掲載。東京・埼玉・神奈川・千葉などの稽古先探しにご活用ください。">
   <link rel="canonical" href="https://kendo-keiko.com/">
   <meta property="og:title" content="剣道オープン稽古会一覧｜関東の合同稽古会情報">
@@ -214,30 +12,683 @@
   <meta property="og:url" content="https://kendo-keiko.com/">
   <meta property="og:site_name" content="剣道オープン稽古会一覧">
   <meta name="twitter:card" content="summary">
+  <style>
+    :root {
+      --paper: #f3f1ec;
+      --surface: #ffffff;
+      --ink: #1b1b1b;
+      --ink-soft: #42403c;
+      --muted: #706d67;
+      --line: #d6d1c8;
+      --line-strong: #8f8a82;
+      --accent: #8c1d24;
+      --accent-dark: #64141a;
+      --footer: #1c1c1c;
+      --content-width: 1080px;
+      --serif: "Yu Mincho", "Hiragino Mincho ProN", "Hiragino Mincho Pro", "Noto Serif JP", serif;
+      --sans: "Yu Gothic", "Hiragino Kaku Gothic ProN", "Meiryo", sans-serif;
+    }
+
+    *,
+    *::before,
+    *::after {
+      box-sizing: border-box;
+    }
+
+    html {
+      background: var(--paper);
+    }
+
+    body {
+      margin: 0;
+      color: var(--ink);
+      background:
+        linear-gradient(rgba(255, 255, 255, 0.38), rgba(255, 255, 255, 0.38)),
+        var(--paper);
+      font-family: var(--sans);
+      font-size: 16px;
+      line-height: 1.8;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    a {
+      color: var(--accent);
+      overflow-wrap: anywhere;
+      text-decoration-thickness: 1px;
+      text-underline-offset: 0.22em;
+    }
+
+    a:hover {
+      color: var(--accent-dark);
+    }
+
+    a:focus-visible,
+    input:focus-visible,
+    select:focus-visible {
+      outline: 3px solid rgba(140, 29, 36, 0.24);
+      outline-offset: 3px;
+    }
+
+    .site-header {
+      background: var(--surface);
+      border-top: 7px solid var(--ink);
+      border-bottom: 1px solid var(--line);
+    }
+
+    .site-header::after {
+      display: block;
+      width: 100%;
+      height: 3px;
+      background: var(--accent);
+      content: "";
+    }
+
+    .site-header__inner {
+      max-width: var(--content-width);
+      margin: 0 auto;
+      padding: 50px 24px 42px;
+    }
+
+    .site-kicker {
+      margin: 0 0 12px;
+      color: var(--accent);
+      font-family: Georgia, "Times New Roman", serif;
+      font-size: 0.72rem;
+      font-weight: 700;
+      letter-spacing: 0.18em;
+    }
+
+    h1,
+    h2,
+    h3 {
+      font-family: var(--serif);
+    }
+
+    h1 {
+      margin: 0;
+      padding-left: 18px;
+      border-left: 5px solid var(--accent);
+      font-size: clamp(1.9rem, 4vw, 2.8rem);
+      font-weight: 600;
+      line-height: 1.35;
+      letter-spacing: 0.05em;
+    }
+
+    .lead {
+      max-width: 870px;
+      margin: 24px 0 18px;
+      color: var(--ink-soft);
+      font-size: 0.98rem;
+      line-height: 2;
+    }
+
+    .meta {
+      display: inline-flex;
+      align-items: center;
+      min-height: 28px;
+      max-width: 100%;
+      padding: 2px 10px;
+      color: var(--muted);
+      background: #f4f3f0;
+      border-left: 3px solid var(--line-strong);
+      font-size: 0.78rem;
+      overflow-wrap: anywhere;
+    }
+
+    .site-main {
+      max-width: var(--content-width);
+      margin: 0 auto;
+      padding: 58px 24px 80px;
+    }
+
+    .search-section,
+    .events-section {
+      margin-bottom: 72px;
+    }
+
+    .section-heading {
+      margin-bottom: 24px;
+      padding-bottom: 14px;
+      border-bottom: 2px solid var(--ink);
+    }
+
+    .section-heading--with-count {
+      display: flex;
+      align-items: end;
+      justify-content: space-between;
+      gap: 24px;
+    }
+
+    .section-heading__en {
+      display: block;
+      margin-bottom: 3px;
+      color: var(--accent);
+      font-family: Georgia, "Times New Roman", serif;
+      font-size: 0.68rem;
+      font-weight: 700;
+      letter-spacing: 0.17em;
+    }
+
+    .section-heading h2 {
+      margin: 0;
+      font-size: clamp(1.4rem, 3vw, 1.95rem);
+      font-weight: 600;
+      line-height: 1.5;
+      letter-spacing: 0.05em;
+    }
+
+    .toolbar {
+      display: grid;
+      grid-template-columns: minmax(0, 2fr) minmax(230px, 1fr);
+      gap: 24px;
+      padding: 28px;
+      background: var(--surface);
+      border-top: 1px solid var(--line-strong);
+      border-bottom: 1px solid var(--line-strong);
+    }
+
+    .form-field {
+      display: block;
+      min-width: 0;
+    }
+
+    .form-field__label {
+      display: block;
+      margin-bottom: 8px;
+      color: var(--ink);
+      font-size: 0.8rem;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+    }
+
+    input,
+    select {
+      width: 100%;
+      min-width: 0;
+      min-height: 48px;
+      padding: 10px 13px;
+      color: var(--ink);
+      background: var(--surface);
+      border: 1px solid var(--line-strong);
+      border-radius: 0;
+      font: inherit;
+      font-size: 16px;
+    }
+
+    input::placeholder {
+      color: #928e87;
+    }
+
+    .count {
+      margin: 0;
+      padding-bottom: 2px;
+      color: var(--muted);
+      font-size: 0.84rem;
+      white-space: nowrap;
+    }
+
+    .cards {
+      display: block;
+      border-top: 1px solid var(--line-strong);
+    }
+
+    .card {
+      position: relative;
+      display: grid;
+      grid-template-columns: 168px minmax(0, 1fr);
+      column-gap: 36px;
+      min-width: 0;
+      padding: 29px 8px 28px;
+      background: transparent;
+      border: 0;
+      border-bottom: 1px solid var(--line);
+      border-radius: 0;
+      box-shadow: none;
+      transition: background-color 160ms ease;
+    }
+
+    .card::before {
+      position: absolute;
+      top: -1px;
+      left: 0;
+      width: 0;
+      height: 2px;
+      background: var(--accent);
+      content: "";
+      transition: width 180ms ease;
+    }
+
+    .card:hover {
+      background: rgba(255, 255, 255, 0.62);
+    }
+
+    .card:hover::before {
+      width: 58px;
+    }
+
+    .card .date {
+      grid-column: 1;
+      grid-row: 1 / span 20;
+      align-self: start;
+      margin: 0;
+      color: var(--ink);
+      font-family: var(--serif);
+      font-size: 1.12rem;
+      font-weight: 600;
+      line-height: 1.5;
+      letter-spacing: 0.02em;
+    }
+
+    .card .org,
+    .card .title,
+    .card .row {
+      grid-column: 2;
+      min-width: 0;
+    }
+
+    .card .org {
+      margin: 0 0 4px;
+      color: var(--accent);
+      font-size: 0.83rem;
+      font-weight: 700;
+      letter-spacing: 0.03em;
+      overflow-wrap: anywhere;
+    }
+
+    .card .title {
+      margin: 0 0 14px;
+      color: var(--ink);
+      font-family: var(--serif);
+      font-size: 1.18rem;
+      font-weight: 600;
+      line-height: 1.6;
+      overflow-wrap: anywhere;
+    }
+
+    .card .row {
+      display: grid;
+      grid-template-columns: 78px minmax(0, 1fr);
+      gap: 12px;
+      margin: 3px 0;
+      color: var(--ink-soft);
+      overflow-wrap: anywhere;
+    }
+
+    .card .label {
+      min-width: 0;
+      color: var(--muted);
+      font-size: 0.76rem;
+      font-weight: 700;
+      letter-spacing: 0.03em;
+    }
+
+    .card .row a {
+      position: relative;
+      width: fit-content;
+      max-width: 100%;
+      padding-right: 1.15em;
+      font-weight: 700;
+      text-decoration: none;
+    }
+
+    .card .row a::after {
+      position: absolute;
+      right: 0;
+      content: "›";
+    }
+
+    .empty,
+    .error {
+      padding: 32px 20px;
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 0;
+      text-align: center;
+      overflow-wrap: anywhere;
+    }
+
+    .organization-section {
+      margin: 0;
+      padding-top: 0;
+      border-top: 0;
+    }
+
+    .organization-section > h2 {
+      margin: 0 0 24px;
+      padding-bottom: 14px;
+      border-bottom: 2px solid var(--ink);
+      font-size: clamp(1.4rem, 3vw, 1.95rem);
+      font-weight: 600;
+      line-height: 1.5;
+      letter-spacing: 0.05em;
+    }
+
+    .organization-section > h2::before {
+      display: block;
+      margin-bottom: 3px;
+      color: var(--accent);
+      font-family: Georgia, "Times New Roman", serif;
+      font-size: 0.68rem;
+      font-weight: 700;
+      letter-spacing: 0.17em;
+      content: "ORGANIZATIONS";
+    }
+
+    .organization-intro {
+      max-width: 800px;
+      margin: -6px 0 22px;
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+
+    .organization-list {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      margin: 0;
+      padding: 0;
+      background: var(--surface);
+      border-top: 1px solid var(--line-strong);
+      list-style: none;
+    }
+
+    .organization-item {
+      min-width: 0;
+      padding: 20px 22px;
+      border-bottom: 1px solid var(--line);
+    }
+
+    .organization-item:nth-child(odd) {
+      border-right: 1px solid var(--line);
+    }
+
+    .organization-item h3 {
+      margin: 0 0 5px;
+      color: var(--ink);
+      font-size: 1rem;
+      font-weight: 600;
+      line-height: 1.6;
+      overflow-wrap: anywhere;
+    }
+
+    .organization-item p {
+      margin: 3px 0;
+      color: var(--muted);
+      font-size: 0.82rem;
+      line-height: 1.75;
+      overflow-wrap: anywhere;
+    }
+
+    .organization-area {
+      color: var(--accent);
+      font-size: 0.74rem;
+      font-weight: 700;
+    }
+
+    .organization-link a {
+      font-weight: 700;
+    }
+
+    .organization-source-note {
+      margin: 18px 0 0;
+      padding: 12px 14px;
+      color: var(--muted);
+      background: rgba(255, 255, 255, 0.62);
+      border-left: 3px solid var(--line-strong);
+      font-size: 0.78rem;
+    }
+
+    .site-footer {
+      color: #d7d4cf;
+      background: var(--footer);
+      border-top: 5px solid var(--accent);
+    }
+
+    .notice {
+      max-width: var(--content-width);
+      margin: 0 auto;
+      padding: 50px 24px 56px;
+      font-size: 0.8rem;
+    }
+
+    .notice h2 {
+      margin: 0 0 20px;
+      color: #ffffff;
+      font-size: 1.25rem;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+    }
+
+    .notice p {
+      max-width: 920px;
+      margin: 10px 0;
+    }
+
+    .notice a {
+      color: #ffffff;
+    }
+
+    @media (max-width: 900px) {
+      .site-header__inner {
+        padding-top: 44px;
+      }
+
+      .site-main {
+        padding-top: 50px;
+      }
+
+      .toolbar {
+        grid-template-columns: minmax(0, 1.5fr) minmax(210px, 1fr);
+        gap: 20px;
+        padding: 24px;
+      }
+
+      .card {
+        grid-template-columns: 145px minmax(0, 1fr);
+        column-gap: 28px;
+      }
+    }
+
+    @media (max-width: 720px) {
+      .site-header__inner {
+        padding: 38px 20px 34px;
+      }
+
+      h1 {
+        padding-left: 14px;
+        border-left-width: 4px;
+      }
+
+      .lead {
+        margin-top: 20px;
+        line-height: 1.9;
+      }
+
+      .site-main {
+        padding: 44px 20px 60px;
+      }
+
+      .search-section,
+      .events-section {
+        margin-bottom: 56px;
+      }
+
+      .toolbar {
+        grid-template-columns: 1fr;
+        gap: 18px;
+        padding: 22px 18px;
+      }
+
+      .section-heading--with-count {
+        display: block;
+      }
+
+      .count {
+        margin-top: 10px;
+      }
+
+      .card {
+        display: block;
+        padding: 24px 2px;
+      }
+
+      .card .date {
+        margin-bottom: 9px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid var(--line);
+        font-size: 1.03rem;
+      }
+
+      .card .row {
+        grid-template-columns: 68px minmax(0, 1fr);
+      }
+
+      .organization-list {
+        grid-template-columns: 1fr;
+      }
+
+      .organization-item:nth-child(odd) {
+        border-right: 0;
+      }
+
+      .organization-item {
+        padding: 18px 14px;
+      }
+
+      .notice {
+        padding-right: 20px;
+        padding-left: 20px;
+      }
+    }
+
+    @media (max-width: 420px) {
+      .site-header {
+        border-top-width: 5px;
+      }
+
+      .site-header__inner {
+        padding: 30px 16px 28px;
+      }
+
+      .site-kicker {
+        margin-bottom: 9px;
+        font-size: 0.62rem;
+        letter-spacing: 0.13em;
+      }
+
+      h1 {
+        padding-left: 12px;
+        font-size: 1.65rem;
+        letter-spacing: 0.03em;
+      }
+
+      .lead {
+        margin: 18px 0 15px;
+        font-size: 0.9rem;
+        line-height: 1.85;
+      }
+
+      .meta {
+        display: flex;
+        width: 100%;
+        font-size: 0.72rem;
+      }
+
+      .site-main {
+        padding: 38px 16px 52px;
+      }
+
+      .section-heading {
+        margin-bottom: 20px;
+      }
+
+      .section-heading h2,
+      .organization-section > h2 {
+        font-size: 1.32rem;
+      }
+
+      .toolbar {
+        padding: 18px 14px;
+      }
+
+      .card {
+        padding: 21px 0;
+      }
+
+      .card .title {
+        font-size: 1.08rem;
+      }
+
+      .card .row {
+        grid-template-columns: 60px minmax(0, 1fr);
+        gap: 8px;
+      }
+
+      .organization-item {
+        padding: 16px 12px;
+      }
+
+      .notice {
+        padding: 42px 16px 48px;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      *,
+      *::before,
+      *::after {
+        scroll-behavior: auto !important;
+        transition-duration: 0.01ms !important;
+      }
+    }
+  </style>
 </head>
 <body>
-  <header>
-    <h1>剣道オープン稽古会一覧</h1>
-<p class="lead">
-  関東を中心に、参加できる剣道のオープン稽古会・合同稽古会情報を掲載しています。
-  東京・埼玉・神奈川・千葉などの稽古会を日付順で確認できます。
-  参加前には必ず各団体・連盟の公式情報をご確認ください。
-</p>
-    <div class="meta" id="meta">読み込み中...</div>
+  <header class="site-header">
+    <div class="site-header__inner">
+      <p class="site-kicker">KENDO OPEN KEIKO INFORMATION</p>
+      <h1>剣道オープン稽古会一覧</h1>
+      <p class="lead">
+        関東を中心に、参加できる剣道のオープン稽古会・合同稽古会情報を掲載しています。
+        東京・埼玉・神奈川・千葉などの稽古会を日付順で確認できます。
+        参加前には必ず各団体・連盟の公式情報をご確認ください。
+      </p>
+      <div class="meta" id="meta">読み込み中...</div>
+    </div>
   </header>
 
-  <main>
+  <main class="site-main">
+    <section class="search-section" aria-labelledby="search-heading">
+      <div class="section-heading">
+        <span class="section-heading__en">SEARCH</span>
+        <h2 id="search-heading">稽古会を探す</h2>
+      </div>
 
+      <div class="toolbar">
+        <label class="form-field">
+          <span class="form-field__label">キーワード</span>
+          <input id="keyword" type="search" placeholder="団体名・会場・タイトルで検索">
+        </label>
 
-    <div class="toolbar">
-      <input id="keyword" type="search" placeholder="団体名・会場・タイトルで検索">
-      <select id="organization">
-        <option value="">すべての団体</option>
-      </select>
-    </div>
+        <label class="form-field">
+          <span class="form-field__label">掲載団体</span>
+          <select id="organization">
+            <option value="">すべての団体</option>
+          </select>
+        </label>
+      </div>
+    </section>
 
-    <div class="count" id="count"></div>
-    <div class="cards" id="cards"></div>
+    <section class="events-section" aria-labelledby="events-heading">
+      <div class="section-heading section-heading--with-count">
+        <div>
+          <span class="section-heading__en">SCHEDULE</span>
+          <h2 id="events-heading">開催予定の稽古会</h2>
+        </div>
+        <div class="count" id="count"></div>
+      </div>
+
+      <div class="cards" id="cards"></div>
+    </section>
 
     <!-- ORGANIZATION_SECTION_START -->
     <section class="organization-section" id="listed-organizations" aria-labelledby="listed-organizations-heading">
@@ -284,7 +735,7 @@
     <!-- ORGANIZATION_SECTION_END -->
   </main>
 
-  <footer>
+  <footer class="site-footer">
     <section class="notice">
       <h2>ご利用にあたって</h2>
       <p>


### PR DESCRIPTION
Closes #16

## 変更内容
- 白・黒・えんじ色を基調としたデザインへ刷新
- ヘッダー、見出し、罫線、余白を調整
- 稽古会一覧を読みやすい一覧形式へ変更
- PC、タブレット、スマートフォンに対応
- 既存JavaScriptと検索・絞り込み機能を維持
- Issue #14の掲載団体生成マーカーを維持

## 確認
- python -m pytest: 23 passed
- 掲載団体セクション再生成済み