### PR TITLE
feat: 基本SEO対応とイベント一覧の静的生成

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,3 +275,9 @@ updated_at
 
 事業的には、剣道団体と参加者をつなぐ小さなサービスとして始め、将来的に団体登録・地域展開・AWS運用事例として活用する。
 
+
+## 基本SEOの静的生成
+
+開催予定はブラウザのJavaScript表示に加え、定期Lambda実行時に `index.html` へ静的生成する。`events.json`、`index.html`、`sitemap.xml` を同じデータ更新サイクルでS3へ発行し、HTMLと表示データの鮮度を揃える。
+
+実装・デプロイ手順は `docs/basic-seo-setup.md` を参照する。

--- a/docs/basic-seo-setup.md
+++ b/docs/basic-seo-setup.md
@@ -1,0 +1,162 @@
+# 基本SEO対応: 静的イベントHTML生成
+
+## 目的
+
+`events.json` をブラウザの JavaScript だけで描画する構成を残しつつ、同じイベント情報を `index.html` にも静的生成する。
+
+これにより、次を実現する。
+
+- 初期HTMLに開催予定の稽古会を含める
+- JavaScriptを実行しないクローラーやブラウザにも内容を伝える
+- `events.json` の取得失敗時も、直前に生成した稽古会一覧を表示する
+- ホームページの `WebSite` 構造化データを追加する
+- イベント更新時に `sitemap.xml` の `lastmod` も更新する
+
+## 更新フロー
+
+```text
+EventBridge Scheduler
+  ↓
+Lambda: KendoKeikoScraper
+  ↓
+DynamoDB更新
+  ↓
+今日以降のイベントをDateIndexから取得
+  ↓
+S3へ同時発行
+  ├─ events.json
+  ├─ index.html（イベントカードを静的生成）
+  └─ sitemap.xml（lastmodを更新）
+```
+
+`index.html` を手動デプロイ時だけ生成すると、イベント情報が古くなる。そこで既存の定期Lambdaから3ファイルをまとめて更新する。
+
+## ローカル確認
+
+```bash
+python -m unittest discover -s tests -v
+```
+
+手元に `public/events.json` がある場合は、次のコマンドでも静的生成を確認できる。
+
+```bash
+python scripts/generate_event_section.py \
+  --events public/events.json \
+  --template public/index.html \
+  --output /tmp/kendo-keiko-index.html
+```
+
+## Lambdaパッケージ作成
+
+```bash
+./scripts/build_lambda.sh
+```
+
+パッケージには以下も含まれる。
+
+- `kendo_keiko/static_site.py`
+- `public/index.html`
+
+## Lambda更新
+
+```bash
+export AWS_REGION=ap-northeast-1
+export FUNCTION_NAME=KendoKeikoScraper
+
+aws lambda update-function-code \
+  --function-name "${FUNCTION_NAME}" \
+  --zip-file fileb://lambda_function.zip \
+  --region "${AWS_REGION}"
+
+aws lambda wait function-updated \
+  --function-name "${FUNCTION_NAME}" \
+  --region "${AWS_REGION}"
+```
+
+## 環境変数
+
+既存の環境変数を消さないよう、現在値を確認してからまとめて更新する。
+
+```bash
+aws lambda get-function-configuration \
+  --function-name "${FUNCTION_NAME}" \
+  --region "${AWS_REGION}" \
+  --query 'Environment.Variables'
+```
+
+追加・確認する値:
+
+```text
+PUBLISH_TO_S3=true
+PUBLISH_INDEX_HTML=true
+EVENTS_BUCKET=<既存のサイト用S3バケット>
+EVENTS_KEY=events.json
+INDEX_KEY=index.html
+SITEMAP_KEY=sitemap.xml
+SITE_URL=https://kendo-keiko.com/
+```
+
+`PUBLISH_INDEX_HTML` 未指定時は、`PUBLISH_TO_S3=true` なら有効になる。ただし運用意図を明確にするため、明示設定を推奨する。
+
+## 手動実行
+
+```bash
+aws lambda invoke \
+  --function-name "${FUNCTION_NAME}" \
+  --region "${AWS_REGION}" \
+  --payload '{}' \
+  --cli-binary-format raw-in-base64-out \
+  /tmp/kendo-keiko-seo-result.json
+
+cat /tmp/kendo-keiko-seo-result.json
+```
+
+レスポンスで次を確認する。
+
+```text
+s3_published: true
+index_published: true
+sitemap_published: true
+```
+
+## S3確認
+
+```bash
+aws s3api head-object \
+  --bucket "${EVENTS_BUCKET}" \
+  --key index.html
+
+aws s3api head-object \
+  --bucket "${EVENTS_BUCKET}" \
+  --key sitemap.xml
+```
+
+初期HTMLにイベントが入っていることを確認する。
+
+```bash
+curl -s https://kendo-keiko.com/ | grep -E \
+  'EVENT_CARDS_START|class="card"|application/ld\+json'
+```
+
+CloudFrontのキャッシュは最大5分を想定している。即時確認が必要な場合だけInvalidationする。
+
+```bash
+aws cloudfront create-invalidation \
+  --distribution-id "${DISTRIBUTION_ID}" \
+  --paths "/" "/index.html" "/sitemap.xml" "/events.json"
+```
+
+## Search Console確認
+
+デプロイ後はURL検査でホームページを確認し、以下を見る。
+
+- クロール済みページのHTMLに稽古会カードが含まれる
+- canonicalが `https://kendo-keiko.com/` になっている
+- sitemapが正常に取得される
+- `WebSite` のサイト名情報がホームページにある
+
+## 今回見送る項目
+
+`Event` 構造化データはトップページの一覧に一括で付けず、個別イベントURLを作る段階で実装する。個別ページを用意した後、イベント名、開始日時、会場、公式情報への導線をページ単位でマークアップする。
+
+また、`www.kendo-keiko.com` と `kendo-keiko.com` の301統一は、CloudFront Function等を使う別Issueとして扱う。

--- a/kendo_keiko/static_site.py
+++ b/kendo_keiko/static_site.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import datetime as dt
+from html import escape
+from pathlib import Path
+from typing import Any, Iterable
+from urllib.parse import urlparse
+
+
+EVENT_META_START = "<!-- EVENT_META_START -->"
+EVENT_META_END = "<!-- EVENT_META_END -->"
+EVENT_COUNT_START = "<!-- EVENT_COUNT_START -->"
+EVENT_COUNT_END = "<!-- EVENT_COUNT_END -->"
+EVENT_CARDS_START = "<!-- EVENT_CARDS_START -->"
+EVENT_CARDS_END = "<!-- EVENT_CARDS_END -->"
+
+
+def safe_http_url(value: object) -> str:
+    if not value:
+        return ""
+
+    url = str(value).strip()
+    parsed = urlparse(url)
+
+    if parsed.scheme not in {"http", "https"}:
+        return ""
+    if not parsed.netloc:
+        return ""
+
+    return url
+
+
+def _text(value: object, fallback: str = "") -> str:
+    if value is None:
+        return fallback
+    text = str(value).strip()
+    return text or fallback
+
+
+def format_event_date(event: dict[str, Any]) -> str:
+    event_date = _text(event.get("event_date"))
+    weekday = _text(event.get("weekday"))
+    return f"{event_date}({weekday})" if weekday else event_date
+
+
+def format_event_time(event: dict[str, Any]) -> str:
+    start_time = _text(event.get("start_time"))
+    end_time = _text(event.get("end_time"))
+
+    if start_time and end_time:
+        return f"{start_time} - {end_time}"
+    if start_time:
+        return start_time
+    return "時間未定"
+
+
+def sort_events(events: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    return sorted(
+        events,
+        key=lambda event: (
+            _text(event.get("event_date")),
+            _text(event.get("start_time")),
+            _text(event.get("organization_id")),
+            _text(event.get("event_id")),
+        ),
+    )
+
+
+def render_event_card(event: dict[str, Any]) -> str:
+    lines = [
+        '        <article class="card">',
+        f'          <div class="date">{escape(format_event_date(event), quote=True)}</div>',
+        (
+            '          <div class="org">'
+            f'{escape(_text(event.get("organization_name")), quote=True)}'
+            '</div>'
+        ),
+    ]
+
+    title = _text(event.get("title"))
+    if title:
+        lines.append(
+            f'          <div class="title">{escape(title, quote=True)}</div>'
+        )
+
+    lines.extend(
+        [
+            (
+                '          <div class="row"><span class="label">時間</span>'
+                f'{escape(format_event_time(event), quote=True)}</div>'
+            ),
+            (
+                '          <div class="row"><span class="label">会場</span>'
+                f'{escape(_text(event.get("venue"), "未取得"), quote=True)}</div>'
+            ),
+            (
+                '          <div class="row"><span class="label">エリア</span>'
+                f'{escape(_text(event.get("area"), "未設定"), quote=True)}</div>'
+            ),
+        ]
+    )
+
+    access = _text(event.get("access"))
+    if access:
+        lines.append(
+            '          <div class="row"><span class="label">アクセス</span>'
+            f'{escape(access, quote=True)}</div>'
+        )
+
+    fee = _text(event.get("fee"))
+    if fee:
+        lines.append(
+            '          <div class="row"><span class="label">参加費</span>'
+            f'{escape(fee, quote=True)}</div>'
+        )
+
+    source_url = safe_http_url(event.get("source_url"))
+    if source_url:
+        lines.extend(
+            [
+                '          <div class="row">',
+                '            <span class="label">公式</span>',
+                (
+                    f'            <a href="{escape(source_url, quote=True)}" '
+                    'target="_blank" rel="noopener noreferrer">'
+                    '公式情報を確認</a>'
+                ),
+                '          </div>',
+            ]
+        )
+
+    lines.append("        </article>")
+    return "\n".join(lines)
+
+
+def render_event_cards(events: list[dict[str, Any]]) -> str:
+    if not events:
+        return '        <div class="empty">現在掲載中の稽古会はありません。</div>'
+
+    return "\n".join(render_event_card(event) for event in events)
+
+
+def _replace_marked_content(
+    html: str,
+    *,
+    start_marker: str,
+    end_marker: str,
+    content: str,
+    indent: str,
+) -> str:
+    start_index = html.find(start_marker)
+    end_index = html.find(end_marker)
+
+    if start_index == -1:
+        raise ValueError(f"開始マーカーが見つかりません: {start_marker}")
+    if end_index == -1:
+        raise ValueError(f"終了マーカーが見つかりません: {end_marker}")
+    if end_index <= start_index:
+        raise ValueError(f"マーカー順序が不正です: {start_marker}")
+
+    content_start = start_index + len(start_marker)
+    return (
+        html[:content_start]
+        + "\n"
+        + content.rstrip()
+        + "\n"
+        + indent
+        + html[end_index:]
+    )
+
+
+def render_static_index(
+    template_html: str,
+    payload: dict[str, Any],
+) -> str:
+    raw_events = payload.get("events", [])
+    if not isinstance(raw_events, list):
+        raise ValueError("events payloadのeventsは配列が必要です")
+
+    events: list[dict[str, Any]] = []
+    for event in raw_events:
+        if not isinstance(event, dict):
+            raise ValueError("events payloadの各要素はオブジェクトが必要です")
+        events.append(event)
+
+    events = sort_events(events)
+    generated_at = _text(payload.get("generated_at"), "-")
+    event_count = len(events)
+
+    html = _replace_marked_content(
+        template_html,
+        start_marker=EVENT_META_START,
+        end_marker=EVENT_META_END,
+        content=(
+            '      <div class="meta" id="meta">'
+            f'更新日時: {escape(generated_at, quote=True)} / '
+            f'掲載件数: {event_count}件</div>'
+        ),
+        indent="      ",
+    )
+    html = _replace_marked_content(
+        html,
+        start_marker=EVENT_COUNT_START,
+        end_marker=EVENT_COUNT_END,
+        content=f'        <div class="count" id="count">{event_count}件掲載中</div>',
+        indent="        ",
+    )
+    html = _replace_marked_content(
+        html,
+        start_marker=EVENT_CARDS_START,
+        end_marker=EVENT_CARDS_END,
+        content=render_event_cards(events),
+        indent="        ",
+    )
+    return html
+
+
+def build_sitemap_xml(
+    *,
+    site_url: str = "https://kendo-keiko.com/",
+    lastmod: dt.date | None = None,
+) -> str:
+    lastmod = lastmod or dt.date.today()
+    safe_site_url = escape(site_url, quote=True)
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+        '  <url>\n'
+        f'    <loc>{safe_site_url}</loc>\n'
+        f'    <lastmod>{lastmod.isoformat()}</lastmod>\n'
+        '    <changefreq>daily</changefreq>\n'
+        '    <priority>1.0</priority>\n'
+        '  </url>\n'
+        '</urlset>\n'
+    )
+
+
+def render_static_index_file(
+    *,
+    template_path: Path,
+    output_path: Path,
+    payload: dict[str, Any],
+) -> None:
+    rendered = render_static_index(
+        template_path.read_text(encoding="utf-8"),
+        payload,
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(rendered, encoding="utf-8")

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -9,6 +9,7 @@ Flow:
   2. Update DynamoDB KendoKeikoEvents
   3. Optionally query DynamoDB DateIndex
   4. Export public events.json to S3
+  5. Pre-render event cards into index.html and refresh sitemap.xml
 
 Environment variables:
   TABLE_NAME=KendoKeikoEvents
@@ -19,6 +20,11 @@ Environment variables:
   PUBLISH_TO_S3=false
   EVENTS_BUCKET=<your-s3-bucket>
   EVENTS_KEY=events.json
+
+  PUBLISH_INDEX_HTML=true
+  INDEX_KEY=index.html
+  SITEMAP_KEY=sitemap.xml
+  SITE_URL=https://kendo-keiko.com/
 """
 
 from __future__ import annotations
@@ -30,6 +36,7 @@ import sys
 from contextlib import redirect_stderr, redirect_stdout
 from decimal import Decimal
 from io import StringIO
+from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo
 
@@ -37,6 +44,7 @@ import boto3
 from boto3.dynamodb.conditions import Key
 
 import export_events
+from kendo_keiko.static_site import build_sitemap_xml, render_static_index
 
 
 JST = ZoneInfo("Asia/Tokyo")
@@ -125,6 +133,25 @@ def build_public_events_payload(
     }
 
 
+def upload_text_to_s3(
+    *,
+    bucket: str,
+    key: str,
+    body: str,
+    content_type: str,
+    region_name: str,
+    cache_control: str = "max-age=300",
+) -> None:
+    s3 = boto3.client("s3", region_name=region_name)
+    s3.put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=body.encode("utf-8"),
+        ContentType=content_type,
+        CacheControl=cache_control,
+    )
+
+
 def upload_events_json_to_s3(
     *,
     bucket: str,
@@ -132,22 +159,25 @@ def upload_events_json_to_s3(
     payload: dict[str, Any],
     region_name: str,
 ) -> None:
-    s3 = boto3.client("s3", region_name=region_name)
-
     body = json.dumps(
         payload,
         ensure_ascii=False,
         indent=2,
         default=json_default,
-    ).encode("utf-8")
-
-    s3.put_object(
-        Bucket=bucket,
-        Key=key,
-        Body=body,
-        ContentType="application/json; charset=utf-8",
-        CacheControl="max-age=300",
     )
+    upload_text_to_s3(
+        bucket=bucket,
+        key=key,
+        body=body,
+        content_type="application/json; charset=utf-8",
+        region_name=region_name,
+    )
+
+
+def build_public_index_html(payload: dict[str, Any]) -> str:
+    template_path = Path(__file__).resolve().parent / "public" / "index.html"
+    template_html = template_path.read_text(encoding="utf-8")
+    return render_static_index(template_html, payload)
 
 
 def run_export_events_main(
@@ -208,6 +238,13 @@ def lambda_handler(event: dict[str, Any] | None, context: Any) -> dict[str, Any]
     )
     events_bucket = event.get("events_bucket") or os.environ.get("EVENTS_BUCKET")
     events_key = event.get("events_key") or os.environ.get("EVENTS_KEY", "events.json")
+    publish_index_html = str_to_bool(
+        event.get("publish_index_html"),
+        str_to_bool(os.environ.get("PUBLISH_INDEX_HTML"), publish_to_s3),
+    )
+    index_key = event.get("index_key") or os.environ.get("INDEX_KEY", "index.html")
+    sitemap_key = event.get("sitemap_key") or os.environ.get("SITEMAP_KEY", "sitemap.xml")
+    site_url = event.get("site_url") or os.environ.get("SITE_URL", "https://kendo-keiko.com/")
     from_date = event.get("from_date") or today_jst().isoformat()
 
     print(
@@ -220,6 +257,10 @@ def lambda_handler(event: dict[str, Any] | None, context: Any) -> dict[str, Any]
                 "publish_to_s3": publish_to_s3,
                 "events_bucket": events_bucket,
                 "events_key": events_key,
+                "publish_index_html": publish_index_html,
+                "index_key": index_key,
+                "sitemap_key": sitemap_key,
+                "site_url": site_url,
                 "from_date": from_date,
             },
             ensure_ascii=False,
@@ -291,7 +332,54 @@ def lambda_handler(event: dict[str, Any] | None, context: Any) -> dict[str, Any]
                 "events_bucket": events_bucket,
                 "events_key": events_key,
                 "event_count": len(events),
+                "index_published": False,
+                "sitemap_published": False,
             }
         )
+
+        if publish_index_html:
+            index_html = build_public_index_html(payload)
+            upload_text_to_s3(
+                bucket=events_bucket,
+                key=index_key,
+                body=index_html,
+                content_type="text/html; charset=utf-8",
+                region_name=region_name,
+            )
+
+            sitemap_xml = build_sitemap_xml(
+                site_url=site_url,
+                lastmod=today_jst(),
+            )
+            upload_text_to_s3(
+                bucket=events_bucket,
+                key=sitemap_key,
+                body=sitemap_xml,
+                content_type="application/xml; charset=utf-8",
+                region_name=region_name,
+                cache_control="max-age=3600",
+            )
+
+            print(
+                json.dumps(
+                    {
+                        "message": "index.html and sitemap.xml uploaded to S3",
+                        "bucket": events_bucket,
+                        "index_key": index_key,
+                        "sitemap_key": sitemap_key,
+                        "event_count": len(events),
+                    },
+                    ensure_ascii=False,
+                )
+            )
+
+            response.update(
+                {
+                    "index_published": True,
+                    "index_key": index_key,
+                    "sitemap_published": True,
+                    "sitemap_key": sitemap_key,
+                }
+            )
 
     return response

--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,16 @@
   <meta property="og:url" content="https://kendo-keiko.com/">
   <meta property="og:site_name" content="剣道オープン稽古会一覧">
   <meta name="twitter:card" content="summary">
+  <meta property="og:locale" content="ja_JP">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "name": "剣道オープン稽古会一覧",
+    "alternateName": "kendo-keiko.com",
+    "url": "https://kendo-keiko.com/"
+  }
+  </script>
   <style>
     :root {
       --paper: #f3f1ec;
@@ -652,7 +662,9 @@
         東京・埼玉・神奈川・千葉などの稽古会を日付順で確認できます。
         参加前には必ず各団体・連盟の公式情報をご確認ください。
       </p>
-      <div class="meta" id="meta">読み込み中...</div>
+      <!-- EVENT_META_START -->
+      <div class="meta" id="meta">稽古会情報を読み込んでいます...</div>
+      <!-- EVENT_META_END -->
     </div>
   </header>
 
@@ -684,10 +696,16 @@
           <span class="section-heading__en">SCHEDULE</span>
           <h2 id="events-heading">開催予定の稽古会</h2>
         </div>
-        <div class="count" id="count"></div>
+        <!-- EVENT_COUNT_START -->
+        <div class="count" id="count">0件掲載中</div>
+        <!-- EVENT_COUNT_END -->
       </div>
 
-      <div class="cards" id="cards"></div>
+      <div class="cards" id="cards">
+        <!-- EVENT_CARDS_START -->
+        <div class="empty">稽古会情報を読み込んでいます...</div>
+        <!-- EVENT_CARDS_END -->
+      </div>
     </section>
 
     <!-- ORGANIZATION_SECTION_START -->
@@ -897,9 +915,14 @@
         document.getElementById("keyword").addEventListener("input", render);
         document.getElementById("organization").addEventListener("change", render);
       } catch (error) {
-        document.getElementById("meta").textContent = "読み込み失敗";
-        document.getElementById("cards").innerHTML =
-          `<div class="error">${escapeHtml(error.message)}</div>`;
+        document.getElementById("meta").textContent =
+          "最新データの読み込みに失敗しました。掲載済み情報を表示しています。";
+
+        const cards = document.getElementById("cards");
+        if (!cards.querySelector(".card")) {
+          cards.innerHTML =
+            `<div class="error">${escapeHtml(error.message)}</div>`;
+        }
       }
     }
 

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://kendo-keiko.com/</loc>
-    <lastmod>2026-07-14</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>

--- a/scripts/build_lambda.sh
+++ b/scripts/build_lambda.sh
@@ -13,13 +13,20 @@ ZIP_PATH="${ROOT_DIR}/lambda_function.zip"
 echo "[INFO] clean build directory"
 rm -rf "${BUILD_DIR}" "${ZIP_PATH}"
 
-mkdir -p "${BUILD_DIR}/data"
+mkdir -p "${BUILD_DIR}/data" "${BUILD_DIR}/public"
 
 echo "[INFO] install dependencies"
 python -m pip install \
   --requirement "${ROOT_DIR}/requirements.txt" \
   --target "${BUILD_DIR}" \
   --quiet
+
+# charset-normalizer の mypyc 拡張はビルド時のPythonマイナーバージョンに
+# 依存する。純Python実装も同梱されているため、Lambda Python 3.12との
+# 互換性を保つ目的で任意の高速化バイナリだけを除去する。
+find "${BUILD_DIR}" -type f \
+  \( -path '*/charset_normalizer/*.so' -o -name '*__mypyc*.so' \) \
+  -delete
 
 echo "[INFO] copy application files"
 cp \
@@ -35,6 +42,10 @@ cp -R \
 cp \
   "${ROOT_DIR}/data/organizations.json" \
   "${BUILD_DIR}/data/organizations.json"
+
+cp \
+  "${ROOT_DIR}/public/index.html" \
+  "${BUILD_DIR}/public/index.html"
 
 echo "[INFO] remove Python cache files"
 find "${BUILD_DIR}" \
@@ -61,6 +72,18 @@ print("[INFO] Lambda package imports: OK")
 PY
 )
 
+echo "[INFO] remove cache files created by import test"
+find "${BUILD_DIR}" \
+  -type d \
+  -name '__pycache__' \
+  -prune \
+  -exec rm -rf {} +
+
+find "${BUILD_DIR}" \
+  -type f \
+  \( -name '*.pyc' -o -name '*.pyo' \) \
+  -delete
+
 echo "[INFO] create ZIP package"
 (
   cd "${BUILD_DIR}"
@@ -75,6 +98,7 @@ required_files=(
   "kendo_keiko/__init__.py"
   "kendo_keiko/models.py"
   "kendo_keiko/pipeline.py"
+  "kendo_keiko/static_site.py"
   "kendo_keiko/scrapers/__init__.py"
   "kendo_keiko/scrapers/ajkf.py"
   "kendo_keiko/scrapers/common.py"
@@ -84,6 +108,7 @@ required_files=(
   "kendo_keiko/scrapers/kenbokukai.py"
   "kendo_keiko/scrapers/tokyo.py"
   "data/organizations.json"
+  "public/index.html"
 )
 
 ZIP_CONTENTS_FILE="$(mktemp)"
@@ -97,6 +122,12 @@ for required_file in "${required_files[@]}"; do
     exit 1
   fi
 done
+
+if grep -Eq '\.(pyc|pyo)$' "${ZIP_CONTENTS_FILE}"; then
+  echo "[ERROR] Python cache file found in ZIP" >&2
+  grep -E '\.(pyc|pyo)$' "${ZIP_CONTENTS_FILE}" >&2
+  exit 1
+fi
 
 echo "[INFO] created: ${ZIP_PATH}"
 ls -lh "${ZIP_PATH}"

--- a/scripts/generate_event_section.py
+++ b/scripts/generate_event_section.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from kendo_keiko.static_site import render_static_index_file
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "events.jsonからトップページの開催予定イベントを静的生成します"
+        )
+    )
+    parser.add_argument(
+        "--events",
+        type=Path,
+        default=Path("public/events.json"),
+    )
+    parser.add_argument(
+        "--template",
+        type=Path,
+        default=Path("public/index.html"),
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("public/index.html"),
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    payload = json.loads(args.events.read_text(encoding="utf-8"))
+
+    if not isinstance(payload, dict):
+        raise ValueError("events.jsonのトップレベルはオブジェクトが必要です")
+
+    render_static_index_file(
+        template_path=args.template,
+        output_path=args.output,
+        payload=payload,
+    )
+
+    print("[INFO] event section generated:", args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_lambda_static_publish.py
+++ b/tests/test_lambda_static_publish.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+import lambda_function
+
+
+class FakeS3Client:
+    def __init__(self) -> None:
+        self.objects: list[dict] = []
+
+    def put_object(self, **kwargs) -> None:
+        self.objects.append(kwargs)
+
+
+class LambdaStaticPublishTests(unittest.TestCase):
+    def test_publishes_events_index_and_sitemap(self) -> None:
+        fake_s3 = FakeS3Client()
+        events = [
+            {
+                "event_id": "event-1",
+                "organization_id": "tokyo",
+                "organization_name": "東京都剣道連盟",
+                "title": "剣道合同稽古会",
+                "event_date": "2026-08-03",
+                "weekday": "月",
+                "start_time": "18:00",
+                "end_time": "20:00",
+                "venue": "東京武道館",
+                "area": "東京都",
+                "source_url": "https://www.tokyo-kendo.or.jp/",
+            }
+        ]
+
+        with (
+            patch.object(
+                lambda_function,
+                "run_export_events_main",
+                return_value={"exit_code": 0, "stdout": "", "stderr": ""},
+            ),
+            patch.object(
+                lambda_function,
+                "query_events_from_dynamodb",
+                return_value=events,
+            ),
+            patch.object(
+                lambda_function.boto3,
+                "client",
+                return_value=fake_s3,
+            ),
+        ):
+            response = lambda_function.lambda_handler(
+                {
+                    "publish_to_s3": True,
+                    "publish_index_html": True,
+                    "events_bucket": "example-bucket",
+                    "from_date": "2026-07-21",
+                },
+                None,
+            )
+
+        objects = {item["Key"]: item for item in fake_s3.objects}
+        self.assertEqual(
+            {"events.json", "index.html", "sitemap.xml"},
+            set(objects),
+        )
+        self.assertEqual(
+            "application/json; charset=utf-8",
+            objects["events.json"]["ContentType"],
+        )
+        self.assertEqual(
+            "text/html; charset=utf-8",
+            objects["index.html"]["ContentType"],
+        )
+        index_html = objects["index.html"]["Body"].decode("utf-8")
+        self.assertIn("2026-08-03(月)", index_html)
+        self.assertIn('"@type": "WebSite"', index_html)
+        sitemap = objects["sitemap.xml"]["Body"].decode("utf-8")
+        self.assertIn("https://kendo-keiko.com/", sitemap)
+        self.assertTrue(response["s3_published"])
+        self.assertTrue(response["index_published"])
+        self.assertTrue(response["sitemap_published"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_static_site.py
+++ b/tests/test_static_site.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import datetime as dt
+import unittest
+from pathlib import Path
+
+from kendo_keiko.static_site import (
+    build_sitemap_xml,
+    render_static_index,
+)
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+INDEX_PATH = ROOT_DIR / "public" / "index.html"
+
+
+class StaticSiteTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.template = INDEX_PATH.read_text(encoding="utf-8")
+        self.payload = {
+            "generated_at": "2026-07-21T10:30:00+09:00",
+            "events": [
+                {
+                    "event_id": "event-2",
+                    "organization_id": "org-b",
+                    "organization_name": "B団体",
+                    "title": "通常稽古",
+                    "event_date": "2026-08-02",
+                    "weekday": "日",
+                    "start_time": None,
+                    "end_time": None,
+                    "venue": None,
+                    "area": None,
+                    "source_url": "javascript:alert(1)",
+                },
+                {
+                    "event_id": "event-1",
+                    "organization_id": "org-a",
+                    "organization_name": "A団体<script>",
+                    "title": "合同稽古 & 交流会",
+                    "event_date": "2026-08-01",
+                    "weekday": "土",
+                    "start_time": "09:00",
+                    "end_time": "11:00",
+                    "venue": "武道館 <大> ",
+                    "area": "東京都",
+                    "access": "駅から5分",
+                    "fee": "500円",
+                    "source_url": "https://example.com/event?id=1&lang=ja",
+                },
+            ],
+        }
+
+    def test_renders_sorted_static_event_cards(self) -> None:
+        rendered = render_static_index(self.template, self.payload)
+
+        first = rendered.index("2026-08-01(土)")
+        second = rendered.index("2026-08-02(日)")
+        self.assertLess(first, second)
+        self.assertIn("掲載件数: 2件", rendered)
+        self.assertIn("2件掲載中", rendered)
+        self.assertIn("A団体&lt;script&gt;", rendered)
+        self.assertIn("合同稽古 &amp; 交流会", rendered)
+        self.assertIn("武道館 &lt;大&gt;", rendered)
+        self.assertIn(
+            'href="https://example.com/event?id=1&amp;lang=ja"',
+            rendered,
+        )
+        self.assertNotIn("javascript:alert(1)", rendered)
+
+    def test_rendering_is_idempotent(self) -> None:
+        once = render_static_index(self.template, self.payload)
+        twice = render_static_index(once, self.payload)
+        self.assertEqual(once, twice)
+
+    def test_renders_empty_state(self) -> None:
+        rendered = render_static_index(
+            self.template,
+            {"generated_at": "2026-07-21T10:30:00+09:00", "events": []},
+        )
+        self.assertIn("掲載件数: 0件", rendered)
+        self.assertIn("現在掲載中の稽古会はありません。", rendered)
+
+    def test_rejects_invalid_events_shape(self) -> None:
+        with self.assertRaises(ValueError):
+            render_static_index(self.template, {"events": {}})
+
+    def test_builds_sitemap_with_lastmod(self) -> None:
+        sitemap = build_sitemap_xml(
+            site_url="https://kendo-keiko.com/",
+            lastmod=dt.date(2026, 7, 21),
+        )
+        self.assertIn("<loc>https://kendo-keiko.com/</loc>", sitemap)
+        self.assertIn("<lastmod>2026-07-21</lastmod>", sitemap)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# 基本SEO対応: 静的イベントHTML生成

## 目的

`events.json` をブラウザの JavaScript だけで描画する構成を残しつつ、同じイベント情報を `index.html` にも静的生成する。

これにより、次を実現する。

- 初期HTMLに開催予定の稽古会を含める
- JavaScriptを実行しないクローラーやブラウザにも内容を伝える
- `events.json` の取得失敗時も、直前に生成した稽古会一覧を表示する
- ホームページの `WebSite` 構造化データを追加する
- イベント更新時に `sitemap.xml` の `lastmod` も更新する

## 更新フロー

```text
EventBridge Scheduler
  ↓
Lambda: KendoKeikoScraper
  ↓
DynamoDB更新
  ↓
今日以降のイベントをDateIndexから取得
  ↓
S3へ同時発行
  ├─ events.json
  ├─ index.html（イベントカードを静的生成）
  └─ sitemap.xml（lastmodを更新）
```

`index.html` を手動デプロイ時だけ生成すると、イベント情報が古くなる。そこで既存の定期Lambdaから3ファイルをまとめて更新する。

## ローカル確認

```bash
python -m unittest discover -s tests -v
```

手元に `public/events.json` がある場合は、次のコマンドでも静的生成を確認できる。

```bash
python scripts/generate_event_section.py \
  --events public/events.json \
  --template public/index.html \
  --output /tmp/kendo-keiko-index.html
```

## Lambdaパッケージ作成

```bash
./scripts/build_lambda.sh
```

パッケージには以下も含まれる。

- `kendo_keiko/static_site.py`
- `public/index.html`

## Lambda更新

```bash
export AWS_REGION=ap-northeast-1
export FUNCTION_NAME=KendoKeikoScraper

aws lambda update-function-code \
  --function-name "${FUNCTION_NAME}" \
  --zip-file fileb://lambda_function.zip \
  --region "${AWS_REGION}"

aws lambda wait function-updated \
  --function-name "${FUNCTION_NAME}" \
  --region "${AWS_REGION}"
```

## 環境変数

既存の環境変数を消さないよう、現在値を確認してからまとめて更新する。

```bash
aws lambda get-function-configuration \
  --function-name "${FUNCTION_NAME}" \
  --region "${AWS_REGION}" \
  --query 'Environment.Variables'
```

追加・確認する値:

```text
PUBLISH_TO_S3=true
PUBLISH_INDEX_HTML=true
EVENTS_BUCKET=<既存のサイト用S3バケット>
EVENTS_KEY=events.json
INDEX_KEY=index.html
SITEMAP_KEY=sitemap.xml
SITE_URL=https://kendo-keiko.com/
```

`PUBLISH_INDEX_HTML` 未指定時は、`PUBLISH_TO_S3=true` なら有効になる。ただし運用意図を明確にするため、明示設定を推奨する。

## 手動実行

```bash
aws lambda invoke \
  --function-name "${FUNCTION_NAME}" \
  --region "${AWS_REGION}" \
  --payload '{}' \
  --cli-binary-format raw-in-base64-out \
  /tmp/kendo-keiko-seo-result.json

cat /tmp/kendo-keiko-seo-result.json
```

レスポンスで次を確認する。

```text
s3_published: true
index_published: true
sitemap_published: true
```

## S3確認

```bash
aws s3api head-object \
  --bucket "${EVENTS_BUCKET}" \
  --key index.html

aws s3api head-object \
  --bucket "${EVENTS_BUCKET}" \
  --key sitemap.xml
```

初期HTMLにイベントが入っていることを確認する。

```bash
curl -s https://kendo-keiko.com/ | grep -E \
  'EVENT_CARDS_START|class="card"|application/ld\+json'
```

CloudFrontのキャッシュは最大5分を想定している。即時確認が必要な場合だけInvalidationする。

```bash
aws cloudfront create-invalidation \
  --distribution-id "${DISTRIBUTION_ID}" \
  --paths "/" "/index.html" "/sitemap.xml" "/events.json"
```

## Search Console確認

デプロイ後はURL検査でホームページを確認し、以下を見る。

- クロール済みページのHTMLに稽古会カードが含まれる
- canonicalが `https://kendo-keiko.com/` になっている
- sitemapが正常に取得される
- `WebSite` のサイト名情報がホームページにある

## 今回見送る項目

`Event` 構造化データはトップページの一覧に一括で付けず、個別イベントURLを作る段階で実装する。個別ページを用意した後、イベント名、開始日時、会場、公式情報への導線をページ単位でマークアップする。

また、`www.kendo-keiko.com` と `kendo-keiko.com` の301統一は、CloudFront Function等を使う別Issueとして扱う。
