### PR TITLE
Step Functionsでスクレイパーを情報源単位に実行する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ cf-config-output.json
 cf-updated-config.json
 cf-update-output.json
 route53-cloudfront-alias-records.json
+
+# Step Functions definitions are source files
+!infra/step-functions/*.asl.json

--- a/docs/step-functions-scraper.md
+++ b/docs/step-functions-scraper.md
@@ -1,0 +1,73 @@
+# Step Functionsによるスクレイパー実行管理
+
+## 目的
+
+団体ごとのスクレイパーを独立して実行し、1団体の失敗で全体を停止させず、成功・0件警告・失敗を確認できるようにする。
+
+## 構成
+
+```text
+EventBridge Scheduler
+  ↓
+Step Functions Standard Workflow
+  ├─ ListSources Lambda
+  ├─ Inline Map（MaxConcurrency: 2）
+  │    └─ ScraperWorker Lambda × 情報源
+  └─ Publisher Lambda
+       ├─ events.json
+       ├─ index.html
+       └─ sitemap.xml
+```
+
+同じZIPパッケージを3つのLambda関数へデプロイし、Handlerだけを分ける。
+
+| 責務 | Handler |
+|---|---|
+| 有効な取得元を列挙 | `list_sources_handler.lambda_handler` |
+| 1団体を取得してDynamoDBへ保存 | `scraper_worker_handler.lambda_handler` |
+| 公開ファイルを生成 | `publisher_handler.lambda_handler` |
+
+既存の `lambda_function.lambda_handler` は、本番切り替えとロールバック確認が終わるまで残す。
+
+## workerの結果
+
+```json
+{
+  "run_id": "example-run",
+  "organization_id": "tokyo",
+  "scraper_type": "tokyo",
+  "status": "success",
+  "event_count": 9,
+  "duration_ms": 1200,
+  "checked_at": "2026-07-22T17:00:00+09:00",
+  "from_date": "2026-07-22",
+  "error_type": null,
+  "error_message": null
+}
+```
+
+未来イベントが0件の場合は `warning` と `empty_result` を返す。例外はLambdaエラーとして再送出し、Step FunctionsのRetryとCatchで処理する。
+
+## 失敗時の扱い
+
+- 一時的なLambdaサービスエラーはStep Functionsが再試行する
+- `requests.RequestException` は `ScraperTransientError` に変換し再試行する
+- 最終失敗はMap内で `failure` 結果へ変換する
+- 一部失敗でもPublisherを実行し、失敗した団体の既存DynamoDBデータは維持する
+- 全団体が `failure` の場合はPublisherが失敗し、公開を行わない
+- 0件の `warning` は公開処理を止めない
+
+## ASL定義
+
+`infra/step-functions/kendo-keiko-scraper.asl.json` の次の値をデプロイ時にLambda ARNへ置換する。
+
+- `${ListSourcesFunctionArn}`
+- `${ScraperWorkerFunctionArn}`
+- `${PublisherFunctionArn}`
+
+## 今回の範囲外
+
+- Step Functions、IAMロール、Schedulerの本番作成
+- CloudWatch AlarmとSNS通知
+- 公式側から消えたイベントの差分反映
+- 手動イベント登録

--- a/export_events.py
+++ b/export_events.py
@@ -37,10 +37,9 @@ from dataclasses import asdict
 from pathlib import Path
 from typing import Optional
 
-import boto3
-
 from kendo_keiko.models import Organization, ServiceEvent
 from kendo_keiko.pipeline import JST, parse_from_date, run_pipeline
+from kendo_keiko.repository import load_organizations, save_dynamodb
 
 DEFAULT_ORGANIZATIONS_PATH = Path("data/organizations.json")
 DEFAULT_EVENTS_OUTPUT_PATH = Path("data/events.json")
@@ -52,13 +51,6 @@ DEFAULT_REGION = "ap-northeast-1"
 def debug_print(enabled: bool, message: str) -> None:
     if enabled:
         print(f"[DEBUG] {message}", file=sys.stderr)
-
-
-def load_organizations(path: Path) -> list[Organization]:
-    raw = json.loads(path.read_text(encoding="utf-8"))
-    return [Organization(**item) for item in raw]
-
-
 
 
 def build_payload(
@@ -99,28 +91,6 @@ def save_json(
         include_past=include_past,
     )
     output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-
-
-def remove_none_values(item: dict) -> dict:
-    """
-    DynamoDBに保存する前に None の属性を除去する。
-    MVPでは NULL として保存するより、属性自体を省略する方が扱いやすい。
-    """
-    return {k: v for k, v in item.items() if v is not None}
-
-
-def save_dynamodb(*, events: list[ServiceEvent], table_name: str, region: str) -> None:
-    """
-    DynamoDBへイベント情報を保存する。
-    同じ event_id のItemは上書きされる。
-    """
-    dynamodb = boto3.resource("dynamodb", region_name=region)
-    table = dynamodb.Table(table_name)
-
-    with table.batch_writer() as batch:
-        for event in events:
-            item = remove_none_values(asdict(event))
-            batch.put_item(Item=item)
 
 
 def format_text(events: list[ServiceEvent]) -> str:

--- a/infra/step-functions/kendo-keiko-scraper.asl.json
+++ b/infra/step-functions/kendo-keiko-scraper.asl.json
@@ -1,0 +1,127 @@
+{
+  "Comment": "Run each kendo scraper independently and publish the combined public site.",
+  "StartAt": "ListEnabledSources",
+  "States": {
+    "ListEnabledSources": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "${ListSourcesFunctionArn}",
+        "Payload.$": "$"
+      },
+      "OutputPath": "$.Payload",
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 2,
+          "BackoffRate": 2.0,
+          "MaxAttempts": 3
+        }
+      ],
+      "Next": "ScrapeSources"
+    },
+    "ScrapeSources": {
+      "Type": "Map",
+      "ItemsPath": "$.sources",
+      "MaxConcurrency": 2,
+      "ItemSelector": {
+        "run_id.$": "$.run_id",
+        "organization_id.$": "$$.Map.Item.Value.organization_id",
+        "table_name.$": "$.table_name",
+        "region.$": "$.region",
+        "from_date.$": "$.from_date",
+        "debug.$": "$.debug"
+      },
+      "ItemProcessor": {
+        "ProcessorConfig": {
+          "Mode": "INLINE"
+        },
+        "StartAt": "InvokeScraperWorker",
+        "States": {
+          "InvokeScraperWorker": {
+            "Type": "Task",
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "Parameters": {
+              "FunctionName": "${ScraperWorkerFunctionArn}",
+              "Payload.$": "$"
+            },
+            "OutputPath": "$.Payload",
+            "Retry": [
+              {
+                "ErrorEquals": [
+                  "Lambda.ServiceException",
+                  "Lambda.AWSLambdaException",
+                  "Lambda.SdkClientException",
+                  "Lambda.TooManyRequestsException"
+                ],
+                "IntervalSeconds": 2,
+                "BackoffRate": 2.0,
+                "MaxAttempts": 3
+              },
+              {
+                "ErrorEquals": ["ScraperTransientError"],
+                "IntervalSeconds": 10,
+                "BackoffRate": 2.0,
+                "MaxAttempts": 2
+              }
+            ],
+            "Catch": [
+              {
+                "ErrorEquals": ["States.ALL"],
+                "ResultPath": "$.error",
+                "Next": "BuildFailureResult"
+              }
+            ],
+            "End": true
+          },
+          "BuildFailureResult": {
+            "Type": "Pass",
+            "Parameters": {
+              "run_id.$": "$.run_id",
+              "organization_id.$": "$.organization_id",
+              "scraper_type": null,
+              "status": "failure",
+              "event_count": 0,
+              "duration_ms": 0,
+              "checked_at.$": "$$.State.EnteredTime",
+              "from_date.$": "$.from_date",
+              "error_type.$": "$.error.Error",
+              "error_message.$": "$.error.Cause"
+            },
+            "End": true
+          }
+        }
+      },
+      "ResultPath": "$.scrape_results",
+      "Next": "PublishPublicSite"
+    },
+    "PublishPublicSite": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "${PublisherFunctionArn}",
+        "Payload.$": "$"
+      },
+      "OutputPath": "$.Payload",
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 2,
+          "BackoffRate": 2.0,
+          "MaxAttempts": 3
+        }
+      ],
+      "End": true
+    }
+  }
+}

--- a/kendo_keiko/models.py
+++ b/kendo_keiko/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Literal, Optional
 
 
 @dataclass(frozen=True)
@@ -16,6 +16,22 @@ class Organization:
     event_type: str
     notes: Optional[str] = None
     public_description: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class ScrapeResult:
+    """One scraper worker execution summary passed through Step Functions."""
+
+    run_id: str
+    organization_id: str
+    scraper_type: str
+    status: Literal["success", "warning", "failure"]
+    event_count: int
+    duration_ms: int
+    checked_at: str
+    from_date: str
+    error_type: Optional[str] = None
+    error_message: Optional[str] = None
 
 
 @dataclass(frozen=True)

--- a/kendo_keiko/publication.py
+++ b/kendo_keiko/publication.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import boto3
+from boto3.dynamodb.conditions import Key
+
+from kendo_keiko.static_site import build_sitemap_xml, render_static_index
+
+
+JST = ZoneInfo("Asia/Tokyo")
+
+
+def json_default(value: Any) -> Any:
+    if isinstance(value, Decimal):
+        if value % 1 == 0:
+            return int(value)
+        return float(value)
+    raise TypeError(
+        f"Object of type {type(value).__name__} is not JSON serializable"
+    )
+
+
+def query_events_from_dynamodb(
+    *,
+    table_name: str,
+    region_name: str,
+    from_date: str,
+) -> list[dict[str, Any]]:
+    dynamodb = boto3.resource("dynamodb", region_name=region_name)
+    table = dynamodb.Table(table_name)
+
+    events: list[dict[str, Any]] = []
+    last_evaluated_key = None
+
+    while True:
+        kwargs: dict[str, Any] = {
+            "IndexName": "DateIndex",
+            "KeyConditionExpression": Key("gsi1_pk").eq("EVENT")
+            & Key("gsi1_sk").gte(from_date),
+        }
+        if last_evaluated_key:
+            kwargs["ExclusiveStartKey"] = last_evaluated_key
+
+        response = table.query(**kwargs)
+        events.extend(response.get("Items", []))
+        last_evaluated_key = response.get("LastEvaluatedKey")
+        if not last_evaluated_key:
+            break
+
+    return sorted(
+        events,
+        key=lambda event: (
+            event.get("event_date", ""),
+            event.get("start_time", ""),
+            event.get("organization_id", ""),
+            event.get("event_id", ""),
+        ),
+    )
+
+
+def build_public_events_payload(
+    *,
+    events: list[dict[str, Any]],
+    table_name: str,
+    region_name: str,
+    from_date: str,
+) -> dict[str, Any]:
+    return {
+        "schema_version": "public-events-0.1",
+        "generated_at": dt.datetime.now(JST).isoformat(timespec="seconds"),
+        "timezone": "Asia/Tokyo",
+        "source": "dynamodb",
+        "table_name": table_name,
+        "region": region_name,
+        "from_date": from_date,
+        "event_count": len(events),
+        "events": events,
+    }
+
+
+def upload_text_to_s3(
+    *,
+    bucket: str,
+    key: str,
+    body: str,
+    content_type: str,
+    region_name: str,
+    cache_control: str = "max-age=300",
+) -> None:
+    s3 = boto3.client("s3", region_name=region_name)
+    s3.put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=body.encode("utf-8"),
+        ContentType=content_type,
+        CacheControl=cache_control,
+    )
+
+
+def upload_events_json_to_s3(
+    *,
+    bucket: str,
+    key: str,
+    payload: dict[str, Any],
+    region_name: str,
+) -> None:
+    body = json.dumps(
+        payload,
+        ensure_ascii=False,
+        indent=2,
+        default=json_default,
+    )
+    upload_text_to_s3(
+        bucket=bucket,
+        key=key,
+        body=body,
+        content_type="application/json; charset=utf-8",
+        region_name=region_name,
+    )
+
+
+def build_public_index_html(payload: dict[str, Any]) -> str:
+    template_path = (
+        Path(__file__).resolve().parent.parent / "public" / "index.html"
+    )
+    template_html = template_path.read_text(encoding="utf-8")
+    return render_static_index(template_html, payload)
+
+
+def publish_public_site(
+    *,
+    table_name: str,
+    region_name: str,
+    from_date: str,
+    events_bucket: str,
+    events_key: str = "events.json",
+    publish_index_html: bool = True,
+    index_key: str = "index.html",
+    sitemap_key: str = "sitemap.xml",
+    site_url: str = "https://kendo-keiko.com/",
+) -> dict[str, Any]:
+    events = query_events_from_dynamodb(
+        table_name=table_name,
+        region_name=region_name,
+        from_date=from_date,
+    )
+    payload = build_public_events_payload(
+        events=events,
+        table_name=table_name,
+        region_name=region_name,
+        from_date=from_date,
+    )
+    upload_events_json_to_s3(
+        bucket=events_bucket,
+        key=events_key,
+        payload=payload,
+        region_name=region_name,
+    )
+
+    result: dict[str, Any] = {
+        "s3_published": True,
+        "events_bucket": events_bucket,
+        "events_key": events_key,
+        "event_count": len(events),
+        "index_published": False,
+        "sitemap_published": False,
+    }
+
+    if publish_index_html:
+        upload_text_to_s3(
+            bucket=events_bucket,
+            key=index_key,
+            body=build_public_index_html(payload),
+            content_type="text/html; charset=utf-8",
+            region_name=region_name,
+        )
+        upload_text_to_s3(
+            bucket=events_bucket,
+            key=sitemap_key,
+            body=build_sitemap_xml(
+                site_url=site_url,
+                lastmod=dt.datetime.now(JST).date(),
+            ),
+            content_type="application/xml; charset=utf-8",
+            region_name=region_name,
+            cache_control="max-age=3600",
+        )
+        result.update(
+            {
+                "index_published": True,
+                "index_key": index_key,
+                "sitemap_published": True,
+                "sitemap_key": sitemap_key,
+            }
+        )
+
+    return result

--- a/kendo_keiko/repository.py
+++ b/kendo_keiko/repository.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+
+import boto3
+
+from kendo_keiko.models import Organization, ServiceEvent
+
+
+DEFAULT_ORGANIZATIONS_PATH = (
+    Path(__file__).resolve().parent.parent / "data" / "organizations.json"
+)
+
+
+def load_organizations(
+    path: Path = DEFAULT_ORGANIZATIONS_PATH,
+) -> list[Organization]:
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, list):
+        raise ValueError("organizations.json must contain a JSON array")
+    return [Organization(**item) for item in raw]
+
+
+def find_organization(
+    organizations: list[Organization],
+    organization_id: str,
+) -> Organization:
+    for organization in organizations:
+        if organization.organization_id == organization_id:
+            return organization
+    raise ValueError(f"organization_id not found: {organization_id}")
+
+
+def remove_none_values(item: dict) -> dict:
+    return {key: value for key, value in item.items() if value is not None}
+
+
+def save_dynamodb(
+    *,
+    events: list[ServiceEvent],
+    table_name: str,
+    region: str,
+) -> None:
+    """Insert or replace event items in DynamoDB."""
+    if not events:
+        return
+
+    dynamodb = boto3.resource("dynamodb", region_name=region)
+    table = dynamodb.Table(table_name)
+
+    with table.batch_writer() as batch:
+        for event in events:
+            batch.put_item(Item=remove_none_values(asdict(event)))

--- a/kendo_keiko/worker.py
+++ b/kendo_keiko/worker.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+import time
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+import requests
+from zoneinfo import ZoneInfo
+
+from kendo_keiko.models import ScrapeResult
+from kendo_keiko.pipeline import parse_from_date, run_pipeline
+from kendo_keiko.repository import (
+    DEFAULT_ORGANIZATIONS_PATH,
+    find_organization,
+    load_organizations,
+    save_dynamodb,
+)
+
+
+JST = ZoneInfo("Asia/Tokyo")
+
+
+class ScraperWorkerError(RuntimeError):
+    """Base error raised by the scraper worker."""
+
+
+class ScraperDisabledError(ScraperWorkerError):
+    """Raised when Step Functions requests a disabled scraper."""
+
+
+class ScraperTransientError(ScraperWorkerError):
+    """Raised for retryable network failures."""
+
+
+def run_scraper_worker(
+    *,
+    organization_id: str,
+    table_name: str,
+    region_name: str,
+    from_date: str | None,
+    run_id: str,
+    debug: bool = False,
+    organizations_path: Path = DEFAULT_ORGANIZATIONS_PATH,
+) -> dict[str, Any]:
+    started = time.perf_counter()
+    checked_at = dt.datetime.now(JST).isoformat(timespec="seconds")
+
+    try:
+        organizations = load_organizations(organizations_path)
+        organization = find_organization(organizations, organization_id)
+        if not organization.scraper_enabled:
+            raise ScraperDisabledError(
+                f"scraper is disabled: {organization_id}"
+            )
+
+        filter_from_date = parse_from_date(from_date)
+        events = run_pipeline(
+            organizations=[organization],
+            scraped_at=checked_at,
+            from_date=filter_from_date,
+            debug=debug,
+        )
+        save_dynamodb(
+            events=events,
+            table_name=table_name,
+            region=region_name,
+        )
+    except Exception as exc:
+        duration_ms = max(0, round((time.perf_counter() - started) * 1000))
+        error = (
+            ScraperTransientError(str(exc))
+            if isinstance(exc, requests.RequestException)
+            else exc
+        )
+        print(
+            json.dumps(
+                {
+                    "message": "scraper worker failed",
+                    "run_id": run_id,
+                    "organization_id": organization_id,
+                    "status": "failure",
+                    "event_count": 0,
+                    "duration_ms": duration_ms,
+                    "checked_at": dt.datetime.now(JST).isoformat(
+                        timespec="seconds"
+                    ),
+                    "error_type": type(error).__name__,
+                    "error_message": str(error),
+                },
+                ensure_ascii=False,
+            )
+        )
+        if error is not exc:
+            raise error from exc
+        raise
+
+    duration_ms = max(0, round((time.perf_counter() - started) * 1000))
+    status = "success" if events else "warning"
+    result = ScrapeResult(
+        run_id=run_id,
+        organization_id=organization.organization_id,
+        scraper_type=organization.scraper_type,
+        status=status,
+        event_count=len(events),
+        duration_ms=duration_ms,
+        checked_at=dt.datetime.now(JST).isoformat(timespec="seconds"),
+        from_date=filter_from_date.isoformat(),
+        error_type="empty_result" if not events else None,
+        error_message=(
+            "No future events were returned by the scraper."
+            if not events
+            else None
+        ),
+    )
+    payload = asdict(result)
+    print(
+        json.dumps(
+            {"message": "scraper worker completed", **payload},
+            ensure_ascii=False,
+        )
+    )
+    return payload

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -34,20 +34,19 @@ import json
 import os
 import sys
 from contextlib import redirect_stderr, redirect_stdout
-from decimal import Decimal
 from io import StringIO
-from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo
 
-import boto3
-from boto3.dynamodb.conditions import Key
-
 import export_events
-from kendo_keiko.static_site import build_sitemap_xml, render_static_index
+from kendo_keiko.publication import publish_public_site
 
 
 JST = ZoneInfo("Asia/Tokyo")
+
+
+def today_jst() -> dt.date:
+    return dt.datetime.now(JST).date()
 
 
 def str_to_bool(value: Any, default: bool = False) -> bool:
@@ -58,126 +57,6 @@ def str_to_bool(value: Any, default: bool = False) -> bool:
         return value
 
     return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
-
-
-def json_default(value: Any) -> Any:
-    if isinstance(value, Decimal):
-        if value % 1 == 0:
-            return int(value)
-        return float(value)
-
-    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
-
-
-def today_jst() -> dt.date:
-    return dt.datetime.now(JST).date()
-
-
-def query_events_from_dynamodb(
-    *,
-    table_name: str,
-    region_name: str,
-    from_date: str,
-) -> list[dict[str, Any]]:
-    dynamodb = boto3.resource("dynamodb", region_name=region_name)
-    table = dynamodb.Table(table_name)
-
-    events: list[dict[str, Any]] = []
-    last_evaluated_key = None
-
-    while True:
-        kwargs: dict[str, Any] = {
-            "IndexName": "DateIndex",
-            "KeyConditionExpression": Key("gsi1_pk").eq("EVENT")
-            & Key("gsi1_sk").gte(from_date),
-        }
-
-        if last_evaluated_key:
-            kwargs["ExclusiveStartKey"] = last_evaluated_key
-
-        response = table.query(**kwargs)
-        events.extend(response.get("Items", []))
-
-        last_evaluated_key = response.get("LastEvaluatedKey")
-        if not last_evaluated_key:
-            break
-
-    return sorted(
-        events,
-        key=lambda e: (
-            e.get("event_date", ""),
-            e.get("start_time", ""),
-            e.get("organization_id", ""),
-            e.get("event_id", ""),
-        ),
-    )
-
-
-def build_public_events_payload(
-    *,
-    events: list[dict[str, Any]],
-    table_name: str,
-    region_name: str,
-    from_date: str,
-) -> dict[str, Any]:
-    return {
-        "schema_version": "public-events-0.1",
-        "generated_at": dt.datetime.now(JST).isoformat(timespec="seconds"),
-        "timezone": "Asia/Tokyo",
-        "source": "dynamodb",
-        "table_name": table_name,
-        "region": region_name,
-        "from_date": from_date,
-        "event_count": len(events),
-        "events": events,
-    }
-
-
-def upload_text_to_s3(
-    *,
-    bucket: str,
-    key: str,
-    body: str,
-    content_type: str,
-    region_name: str,
-    cache_control: str = "max-age=300",
-) -> None:
-    s3 = boto3.client("s3", region_name=region_name)
-    s3.put_object(
-        Bucket=bucket,
-        Key=key,
-        Body=body.encode("utf-8"),
-        ContentType=content_type,
-        CacheControl=cache_control,
-    )
-
-
-def upload_events_json_to_s3(
-    *,
-    bucket: str,
-    key: str,
-    payload: dict[str, Any],
-    region_name: str,
-) -> None:
-    body = json.dumps(
-        payload,
-        ensure_ascii=False,
-        indent=2,
-        default=json_default,
-    )
-    upload_text_to_s3(
-        bucket=bucket,
-        key=key,
-        body=body,
-        content_type="application/json; charset=utf-8",
-        region_name=region_name,
-    )
-
-
-def build_public_index_html(payload: dict[str, Any]) -> str:
-    template_path = Path(__file__).resolve().parent / "public" / "index.html"
-    template_html = template_path.read_text(encoding="utf-8")
-    return render_static_index(template_html, payload)
 
 
 def run_export_events_main(
@@ -296,90 +175,26 @@ def lambda_handler(event: dict[str, Any] | None, context: Any) -> dict[str, Any]
         if not events_bucket:
             raise ValueError("PUBLISH_TO_S3 is true, but EVENTS_BUCKET is not set.")
 
-        events = query_events_from_dynamodb(
+        publish_result = publish_public_site(
             table_name=table_name,
             region_name=region_name,
             from_date=from_date,
+            events_bucket=events_bucket,
+            events_key=events_key,
+            publish_index_html=publish_index_html,
+            index_key=index_key,
+            sitemap_key=sitemap_key,
+            site_url=site_url,
         )
-        payload = build_public_events_payload(
-            events=events,
-            table_name=table_name,
-            region_name=region_name,
-            from_date=from_date,
-        )
-        upload_events_json_to_s3(
-            bucket=events_bucket,
-            key=events_key,
-            payload=payload,
-            region_name=region_name,
-        )
-
+        response.update(publish_result)
         print(
             json.dumps(
                 {
-                    "message": "events.json uploaded to S3",
-                    "bucket": events_bucket,
-                    "key": events_key,
-                    "event_count": len(events),
+                    "message": "public site files uploaded to S3",
+                    **publish_result,
                 },
                 ensure_ascii=False,
             )
         )
-
-        response.update(
-            {
-                "s3_published": True,
-                "events_bucket": events_bucket,
-                "events_key": events_key,
-                "event_count": len(events),
-                "index_published": False,
-                "sitemap_published": False,
-            }
-        )
-
-        if publish_index_html:
-            index_html = build_public_index_html(payload)
-            upload_text_to_s3(
-                bucket=events_bucket,
-                key=index_key,
-                body=index_html,
-                content_type="text/html; charset=utf-8",
-                region_name=region_name,
-            )
-
-            sitemap_xml = build_sitemap_xml(
-                site_url=site_url,
-                lastmod=today_jst(),
-            )
-            upload_text_to_s3(
-                bucket=events_bucket,
-                key=sitemap_key,
-                body=sitemap_xml,
-                content_type="application/xml; charset=utf-8",
-                region_name=region_name,
-                cache_control="max-age=3600",
-            )
-
-            print(
-                json.dumps(
-                    {
-                        "message": "index.html and sitemap.xml uploaded to S3",
-                        "bucket": events_bucket,
-                        "index_key": index_key,
-                        "sitemap_key": sitemap_key,
-                        "event_count": len(events),
-                    },
-                    ensure_ascii=False,
-                )
-            )
-
-            response.update(
-                {
-                    "index_published": True,
-                    "index_key": index_key,
-                    "sitemap_published": True,
-                    "sitemap_key": sitemap_key,
-                }
-            )
 
     return response

--- a/list_sources_handler.py
+++ b/list_sources_handler.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import datetime as dt
+import os
+import uuid
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from kendo_keiko.repository import (
+    DEFAULT_ORGANIZATIONS_PATH,
+    load_organizations,
+)
+
+
+JST = ZoneInfo("Asia/Tokyo")
+
+
+def str_to_bool(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def lambda_handler(event: dict[str, Any] | None, context: Any) -> dict[str, Any]:
+    event = event or {}
+    organizations_path = Path(
+        event.get("organizations_path")
+        or os.environ.get(
+            "ORGANIZATIONS_PATH",
+            str(DEFAULT_ORGANIZATIONS_PATH),
+        )
+    )
+    organizations = load_organizations(organizations_path)
+    sources = [
+        {"organization_id": organization.organization_id}
+        for organization in organizations
+        if organization.scraper_enabled
+    ]
+    if not sources:
+        raise ValueError("No enabled scraper sources were found.")
+
+    request_id = getattr(context, "aws_request_id", None)
+    run_id = event.get("run_id") or request_id or str(uuid.uuid4())
+    from_date = event.get("from_date") or dt.datetime.now(JST).date().isoformat()
+
+    return {
+        "run_id": run_id,
+        "table_name": event.get("table_name")
+        or os.environ.get("TABLE_NAME", "KendoKeikoEvents"),
+        "region": event.get("region")
+        or os.environ.get("AWS_REGION", "ap-northeast-1"),
+        "from_date": from_date,
+        "debug": str_to_bool(
+            event.get("debug"),
+            str_to_bool(os.environ.get("DEBUG"), False),
+        ),
+        "publish_to_s3": str_to_bool(
+            event.get("publish_to_s3"),
+            str_to_bool(os.environ.get("PUBLISH_TO_S3"), True),
+        ),
+        "publish_index_html": str_to_bool(
+            event.get("publish_index_html"),
+            str_to_bool(os.environ.get("PUBLISH_INDEX_HTML"), True),
+        ),
+        "events_bucket": event.get("events_bucket")
+        or os.environ.get("EVENTS_BUCKET"),
+        "events_key": event.get("events_key")
+        or os.environ.get("EVENTS_KEY", "events.json"),
+        "index_key": event.get("index_key")
+        or os.environ.get("INDEX_KEY", "index.html"),
+        "sitemap_key": event.get("sitemap_key")
+        or os.environ.get("SITEMAP_KEY", "sitemap.xml"),
+        "site_url": event.get("site_url")
+        or os.environ.get("SITE_URL", "https://kendo-keiko.com/"),
+        "sources": sources,
+    }

--- a/publisher_handler.py
+++ b/publisher_handler.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+import os
+from collections import Counter
+from typing import Any
+
+from kendo_keiko.publication import publish_public_site
+
+
+class AllSourcesFailedError(RuntimeError):
+    """Raised when no scraper source completed successfully or with warning."""
+
+
+def str_to_bool(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def lambda_handler(event: dict[str, Any] | None, context: Any) -> dict[str, Any]:
+    event = event or {}
+    results = event.get("scrape_results")
+    if not isinstance(results, list) or not results:
+        raise ValueError("scrape_results must be a non-empty array")
+
+    statuses = [str(result.get("status")) for result in results]
+    invalid_statuses = sorted(set(statuses) - {"success", "warning", "failure"})
+    if invalid_statuses:
+        raise ValueError(
+            f"Unknown scrape result status: {', '.join(invalid_statuses)}"
+        )
+
+    counts = Counter(statuses)
+    if counts["failure"] == len(results):
+        raise AllSourcesFailedError("All scraper sources failed; publishing skipped.")
+
+    response: dict[str, Any] = {
+        "run_id": event.get("run_id"),
+        "source_count": len(results),
+        "success_count": counts["success"],
+        "warning_count": counts["warning"],
+        "failure_count": counts["failure"],
+        "s3_published": False,
+    }
+
+    publish_to_s3 = str_to_bool(
+        event.get("publish_to_s3"),
+        str_to_bool(os.environ.get("PUBLISH_TO_S3"), True),
+    )
+    if publish_to_s3:
+        events_bucket = event.get("events_bucket") or os.environ.get(
+            "EVENTS_BUCKET"
+        )
+        if not events_bucket:
+            raise ValueError("EVENTS_BUCKET is required when publishing is enabled")
+
+        response.update(
+            publish_public_site(
+                table_name=event.get("table_name")
+                or os.environ.get("TABLE_NAME", "KendoKeikoEvents"),
+                region_name=event.get("region")
+                or os.environ.get("AWS_REGION", "ap-northeast-1"),
+                from_date=event.get("from_date"),
+                events_bucket=events_bucket,
+                events_key=event.get("events_key")
+                or os.environ.get("EVENTS_KEY", "events.json"),
+                publish_index_html=str_to_bool(
+                    event.get("publish_index_html"),
+                    str_to_bool(os.environ.get("PUBLISH_INDEX_HTML"), True),
+                ),
+                index_key=event.get("index_key")
+                or os.environ.get("INDEX_KEY", "index.html"),
+                sitemap_key=event.get("sitemap_key")
+                or os.environ.get("SITEMAP_KEY", "sitemap.xml"),
+                site_url=event.get("site_url")
+                or os.environ.get("SITE_URL", "https://kendo-keiko.com/"),
+            )
+        )
+
+    print(
+        json.dumps(
+            {"message": "scraper workflow completed", **response},
+            ensure_ascii=False,
+        )
+    )
+    return response

--- a/scraper_worker_handler.py
+++ b/scraper_worker_handler.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from kendo_keiko.worker import run_scraper_worker
+
+
+def str_to_bool(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def lambda_handler(event: dict[str, Any] | None, context: Any) -> dict[str, Any]:
+    event = event or {}
+    organization_id = event.get("organization_id")
+    if not organization_id:
+        raise ValueError("organization_id is required")
+
+    run_id = event.get("run_id") or getattr(context, "aws_request_id", "unknown")
+    return run_scraper_worker(
+        organization_id=organization_id,
+        table_name=event.get("table_name")
+        or os.environ.get("TABLE_NAME", "KendoKeikoEvents"),
+        region_name=event.get("region")
+        or os.environ.get("AWS_REGION", "ap-northeast-1"),
+        from_date=event.get("from_date"),
+        run_id=run_id,
+        debug=str_to_bool(
+            event.get("debug"),
+            str_to_bool(os.environ.get("DEBUG"), False),
+        ),
+    )

--- a/scripts/build_lambda.sh
+++ b/scripts/build_lambda.sh
@@ -33,6 +33,9 @@ cp \
   "${ROOT_DIR}/export_events.py" \
   "${ROOT_DIR}/scrape_kendo_schedule.py" \
   "${ROOT_DIR}/lambda_function.py" \
+  "${ROOT_DIR}/list_sources_handler.py" \
+  "${ROOT_DIR}/scraper_worker_handler.py" \
+  "${ROOT_DIR}/publisher_handler.py" \
   "${BUILD_DIR}/"
 
 cp -R \
@@ -65,7 +68,10 @@ echo "[INFO] test imports from build directory"
 
   PYTHONPATH="${BUILD_DIR}" python - <<'PY'
 import lambda_function
-from kendo_keiko.models import RawScrapedEvent
+import list_sources_handler
+import publisher_handler
+import scraper_worker_handler
+from kendo_keiko.models import RawScrapedEvent, ScrapeResult
 from kendo_keiko.scrapers.ajkf import scrape
 
 print("[INFO] Lambda package imports: OK")
@@ -93,12 +99,18 @@ echo "[INFO] create ZIP package"
 echo "[INFO] verify ZIP contents"
 required_files=(
   "lambda_function.py"
+  "list_sources_handler.py"
+  "scraper_worker_handler.py"
+  "publisher_handler.py"
   "export_events.py"
   "scrape_kendo_schedule.py"
   "kendo_keiko/__init__.py"
   "kendo_keiko/models.py"
   "kendo_keiko/pipeline.py"
+  "kendo_keiko/publication.py"
+  "kendo_keiko/repository.py"
   "kendo_keiko/static_site.py"
+  "kendo_keiko/worker.py"
   "kendo_keiko/scrapers/__init__.py"
   "kendo_keiko/scrapers/ajkf.py"
   "kendo_keiko/scrapers/common.py"

--- a/tests/test_lambda_static_publish.py
+++ b/tests/test_lambda_static_publish.py
@@ -4,6 +4,7 @@ import unittest
 from unittest.mock import patch
 
 import lambda_function
+import kendo_keiko.publication as publication
 
 
 class FakeS3Client:
@@ -40,12 +41,12 @@ class LambdaStaticPublishTests(unittest.TestCase):
                 return_value={"exit_code": 0, "stdout": "", "stderr": ""},
             ),
             patch.object(
-                lambda_function,
+                publication,
                 "query_events_from_dynamodb",
                 return_value=events,
             ),
             patch.object(
-                lambda_function.boto3,
+                publication.boto3,
                 "client",
                 return_value=fake_s3,
             ),

--- a/tests/test_scraper_worker.py
+++ b/tests/test_scraper_worker.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import datetime as dt
+import unittest
+from unittest.mock import Mock, patch
+
+import requests
+
+from kendo_keiko.models import Organization, ServiceEvent
+from kendo_keiko.worker import (
+    ScraperTransientError,
+    run_scraper_worker,
+)
+
+
+class ScraperWorkerTests(unittest.TestCase):
+    def make_organization(self) -> Organization:
+        return Organization(
+            organization_id="test-org",
+            name="テスト団体",
+            area="東京都",
+            website_url="https://example.com/",
+            source_type="official_site",
+            scraper_type="test-scraper",
+            scraper_enabled=True,
+            event_type="open_keiko",
+        )
+
+    def make_event(self) -> ServiceEvent:
+        return ServiceEvent(
+            event_id="test-org-20260801-1900-12345678",
+            organization_id="test-org",
+            organization_name="テスト団体",
+            event_type="open_keiko",
+            title="通常稽古",
+            event_date="2026-08-01",
+            weekday="土",
+            start_time="19:00",
+            end_time="20:30",
+            venue="テスト武道館",
+            area="東京都",
+            address=None,
+            access=None,
+            fee=None,
+            application_required=False,
+            source_url="https://example.com/",
+            source_type="official_site",
+            last_scraped_at="2026-07-22T17:00:00+09:00",
+            status="active",
+            raw_note=None,
+            gsi1_pk="EVENT",
+            gsi1_sk=(
+                "2026-08-01#19:00#test-org#"
+                "test-org-20260801-1900-12345678"
+            ),
+        )
+
+    def test_returns_success_and_saves_events(self) -> None:
+        organization = self.make_organization()
+        events = [self.make_event()]
+
+        with (
+            patch(
+                "kendo_keiko.worker.load_organizations",
+                return_value=[organization],
+            ),
+            patch(
+                "kendo_keiko.worker.run_pipeline",
+                return_value=events,
+            ) as run_pipeline,
+            patch("kendo_keiko.worker.save_dynamodb") as save_dynamodb,
+            patch(
+                "kendo_keiko.worker.time.perf_counter",
+                side_effect=[10.0, 10.125],
+            ),
+        ):
+            result = run_scraper_worker(
+                organization_id="test-org",
+                table_name="KendoKeikoEvents",
+                region_name="ap-northeast-1",
+                from_date="2026-07-22",
+                run_id="run-1",
+            )
+
+        self.assertEqual("success", result["status"])
+        self.assertEqual(1, result["event_count"])
+        self.assertEqual(125, result["duration_ms"])
+        self.assertIsNone(result["error_type"])
+        run_pipeline.assert_called_once()
+        self.assertEqual(
+            dt.date(2026, 7, 22),
+            run_pipeline.call_args.kwargs["from_date"],
+        )
+        save_dynamodb.assert_called_once_with(
+            events=events,
+            table_name="KendoKeikoEvents",
+            region="ap-northeast-1",
+        )
+
+    def test_returns_warning_for_empty_result(self) -> None:
+        organization = self.make_organization()
+
+        with (
+            patch(
+                "kendo_keiko.worker.load_organizations",
+                return_value=[organization],
+            ),
+            patch("kendo_keiko.worker.run_pipeline", return_value=[]),
+            patch("kendo_keiko.worker.save_dynamodb") as save_dynamodb,
+        ):
+            result = run_scraper_worker(
+                organization_id="test-org",
+                table_name="KendoKeikoEvents",
+                region_name="ap-northeast-1",
+                from_date="2026-07-22",
+                run_id="run-2",
+            )
+
+        self.assertEqual("warning", result["status"])
+        self.assertEqual(0, result["event_count"])
+        self.assertEqual("empty_result", result["error_type"])
+        save_dynamodb.assert_called_once_with(
+            events=[],
+            table_name="KendoKeikoEvents",
+            region="ap-northeast-1",
+        )
+
+    def test_converts_request_error_to_transient_error(self) -> None:
+        organization = self.make_organization()
+
+        with (
+            patch(
+                "kendo_keiko.worker.load_organizations",
+                return_value=[organization],
+            ),
+            patch(
+                "kendo_keiko.worker.run_pipeline",
+                side_effect=requests.Timeout("timed out"),
+            ),
+        ):
+            with self.assertRaises(ScraperTransientError):
+                run_scraper_worker(
+                    organization_id="test-org",
+                    table_name="KendoKeikoEvents",
+                    region_name="ap-northeast-1",
+                    from_date="2026-07-22",
+                    run_id="run-3",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_step_functions_definition.py
+++ b/tests/test_step_functions_definition.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+
+class StepFunctionsDefinitionTests(unittest.TestCase):
+    def test_definition_uses_inline_map_and_three_handlers(self) -> None:
+        path = Path("infra/step-functions/kendo-keiko-scraper.asl.json")
+        definition = json.loads(path.read_text(encoding="utf-8"))
+
+        states = definition["States"]
+        self.assertEqual("ListEnabledSources", definition["StartAt"])
+        self.assertEqual(2, states["ScrapeSources"]["MaxConcurrency"])
+        self.assertEqual(
+            "INLINE",
+            states["ScrapeSources"]["ItemProcessor"]["ProcessorConfig"][
+                "Mode"
+            ],
+        )
+        self.assertEqual(
+            "${ListSourcesFunctionArn}",
+            states["ListEnabledSources"]["Parameters"]["FunctionName"],
+        )
+        self.assertEqual(
+            "${PublisherFunctionArn}",
+            states["PublishPublicSite"]["Parameters"]["FunctionName"],
+        )
+        worker = states["ScrapeSources"]["ItemProcessor"]["States"][
+            "InvokeScraperWorker"
+        ]
+        self.assertEqual(
+            "${ScraperWorkerFunctionArn}",
+            worker["Parameters"]["FunctionName"],
+        )
+        self.assertEqual("BuildFailureResult", worker["Catch"][0]["Next"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_step_functions_handlers.py
+++ b/tests/test_step_functions_handlers.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+import list_sources_handler
+import publisher_handler
+from kendo_keiko.models import Organization
+
+
+class FakeContext:
+    aws_request_id = "request-123"
+
+
+class ListSourcesHandlerTests(unittest.TestCase):
+    def test_lists_only_enabled_sources(self) -> None:
+        enabled = Organization(
+            organization_id="enabled",
+            name="有効団体",
+            area="東京都",
+            website_url="https://example.com/enabled",
+            source_type="official_site",
+            scraper_type="enabled",
+            scraper_enabled=True,
+            event_type="open_keiko",
+        )
+        disabled = Organization(
+            organization_id="disabled",
+            name="無効団体",
+            area="東京都",
+            website_url="https://example.com/disabled",
+            source_type="official_site",
+            scraper_type="disabled",
+            scraper_enabled=False,
+            event_type="open_keiko",
+        )
+
+        with patch.object(
+            list_sources_handler,
+            "load_organizations",
+            return_value=[enabled, disabled],
+        ):
+            result = list_sources_handler.lambda_handler(
+                {
+                    "from_date": "2026-07-22",
+                    "events_bucket": "example-bucket",
+                },
+                FakeContext(),
+            )
+
+        self.assertEqual("request-123", result["run_id"])
+        self.assertEqual(
+            [{"organization_id": "enabled"}],
+            result["sources"],
+        )
+        self.assertEqual("example-bucket", result["events_bucket"])
+
+
+class PublisherHandlerTests(unittest.TestCase):
+    def test_skips_publish_when_all_sources_failed(self) -> None:
+        with self.assertRaises(publisher_handler.AllSourcesFailedError):
+            publisher_handler.lambda_handler(
+                {
+                    "scrape_results": [
+                        {"organization_id": "a", "status": "failure"},
+                        {"organization_id": "b", "status": "failure"},
+                    ]
+                },
+                None,
+            )
+
+    def test_rejects_unknown_status(self) -> None:
+        with self.assertRaisesRegex(ValueError, "Unknown scrape result status"):
+            publisher_handler.lambda_handler(
+                {
+                    "scrape_results": [
+                        {"organization_id": "a", "status": "unknown"}
+                    ]
+                },
+                None,
+            )
+
+    def test_publishes_when_at_least_one_source_did_not_fail(self) -> None:
+        publish_result = {
+            "s3_published": True,
+            "event_count": 10,
+            "index_published": True,
+            "sitemap_published": True,
+        }
+        with patch.object(
+            publisher_handler,
+            "publish_public_site",
+            return_value=publish_result,
+        ) as publish:
+            result = publisher_handler.lambda_handler(
+                {
+                    "run_id": "run-1",
+                    "table_name": "KendoKeikoEvents",
+                    "region": "ap-northeast-1",
+                    "from_date": "2026-07-22",
+                    "events_bucket": "example-bucket",
+                    "scrape_results": [
+                        {"organization_id": "a", "status": "success"},
+                        {"organization_id": "b", "status": "warning"},
+                        {"organization_id": "c", "status": "failure"},
+                    ],
+                },
+                None,
+            )
+
+        self.assertEqual(1, result["success_count"])
+        self.assertEqual(1, result["warning_count"])
+        self.assertEqual(1, result["failure_count"])
+        self.assertTrue(result["s3_published"])
+        publish.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要

スクレイパーの実行管理をAWS Step Functionsへ移行するための基盤を追加しました。

Refs #21

## 主な変更

- Step Functions Standard WorkflowのASL定義を追加
- Inline Mapで情報源単位にスクレイパーを実行
- 同時実行数を2に制限
- Lambdaを以下の3つの責務に分割
  - 取得元一覧の生成
  - 1情報源単位のスクレイピング
  - DynamoDBからの公開ファイル生成
- スクレイピング結果をsuccess / warning / failureで管理
- 0件取得をempty_resultのwarningとして記録
- 一時的な通信エラーをStep FunctionsのRetry対象として送出
- 全情報源失敗時は公開処理を停止
- 既存のlambda_function.lambda_handlerは移行期間中の互換性のため維持
- Step Functions構成と運用方針のドキュメントを追加

## テスト

- 既存テストを含む41テスト成功
- Lambda ZIPのimportテスト成功
- ZIP破損チェック成功
- Step Functions ASLのAWSバリデーション成功

## AWS動作確認

Step Functionsを手動実行し、本番AWS環境で確認しました。

- 情報源数: 6
- success: 6
- warning: 0
- failure: 0
- 公開イベント数: 38
- events.json: 公開成功
- index.html: 公開成功
- sitemap.xml: 公開成功
- CloudFront Invalidation: 完了
- 公開サイト: HTTP 200

## 残作業

- EventBridge SchedulerのStep Functionsへの切り替え
- 失敗検知用CloudWatch Alarm
- SNS通知
- Scheduler未実行の検知