### PR TITLE
feat: 稽古会イベントに取得方式・参加条件・確認日を追加する

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -30,11 +30,62 @@
 - `venue`: 会場名
 - `area`: エリア
 - `fee`: 参加費
-- `application_required`: 申し込み必須かどうか
+- `application_required`: 申し込み必須かどうかを既存処理で推定した値
 - `source_url`: 公式情報URL
 - `source_type`: 情報取得元種別
 - `last_scraped_at`: 最終取得日時
 - `status`: `active` / `cancelled` / `unknown`
+- `update_mode`: イベント情報の更新方式
+- `participation_type`: イベントの参加条件
+- `verified_at`: 内容を人が確認した日時。未確認は `null`
+
+### update_mode
+
+許可する値:
+
+- `automatic`: スクレイパー等による自動取得
+- `assisted`: 自動取得結果を人が補助して更新
+- `manual`: 管理者が手動で登録・更新
+
+自動スクレイパーが新規生成するイベントには `automatic` を明示する。
+`ServiceEvent` 全体の暗黙のデフォルト値にはせず、将来の手動登録で誤分類しないようにする。
+
+Issue #22以前に保存されたDynamoDB項目で属性が存在しない場合のみ、読み込み時の後方互換値として `automatic` を補う。
+
+### participation_type
+
+許可する値:
+
+- `anyone`: 一般参加可能
+- `contact_required`: 事前連絡が必要
+- `registration_required`: 事前申し込みが必要
+- `invitation_required`: 招待が必要
+- `members_only`: 会員・所属者限定
+- `unknown`: 公式情報から判断できない
+
+Issue #22の最初のPRでは、既存の `application_required` から機械的に変換せず、新規自動取得イベントには `unknown` を設定する。誤判定を避け、参加条件の具体的な設定は情報源・イベントごとに追加する。
+
+### verified_at
+
+`verified_at` は ISO 8601形式かつタイムゾーン付きの日時、または `null` とする。
+
+自動取得時刻をそのまま人による確認日時とは扱わないため、新規自動取得イベントは当面 `null` とする。DynamoDBでは未確認という状態を保持するため、`NULL` 属性として保存する。
+
+Issue #22以前のDynamoDB項目に属性がない場合は、公開JSON生成時に `null` を補う。
+
+## 公開JSONの後方互換性
+
+Issue #22以前のイベントに新しい3属性がない場合、DynamoDB読み込み・公開JSON生成時に次を補う。
+
+```json
+{
+  "update_mode": "automatic",
+  "participation_type": "unknown",
+  "verified_at": null
+}
+```
+
+明示的に存在する不正な値は補正せず、バリデーションエラーにする。
 
 ## 保存先
 

--- a/export_events.py
+++ b/export_events.py
@@ -62,7 +62,7 @@ def build_payload(
     include_past: bool,
 ) -> dict:
     return {
-        "schema_version": "0.2",
+        "schema_version": "0.3",
         "generated_at": scraped_at,
         "timezone": "Asia/Tokyo",
         "from_date": from_date,

--- a/kendo_keiko/models.py
+++ b/kendo_keiko/models.py
@@ -1,7 +1,90 @@
 from __future__ import annotations
 
+import datetime as dt
 from dataclasses import dataclass
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
+
+
+UpdateMode = Literal["automatic", "assisted", "manual"]
+ParticipationType = Literal[
+    "anyone",
+    "contact_required",
+    "registration_required",
+    "invitation_required",
+    "members_only",
+    "unknown",
+]
+
+VALID_UPDATE_MODES = frozenset({"automatic", "assisted", "manual"})
+VALID_PARTICIPATION_TYPES = frozenset(
+    {
+        "anyone",
+        "contact_required",
+        "registration_required",
+        "invitation_required",
+        "members_only",
+        "unknown",
+    }
+)
+
+LEGACY_UPDATE_MODE: UpdateMode = "automatic"
+LEGACY_PARTICIPATION_TYPE: ParticipationType = "unknown"
+
+
+def validate_event_metadata(
+    *,
+    update_mode: str,
+    participation_type: str,
+    verified_at: Optional[str],
+) -> None:
+    if update_mode not in VALID_UPDATE_MODES:
+        raise ValueError(f"invalid update_mode: {update_mode}")
+
+    if participation_type not in VALID_PARTICIPATION_TYPES:
+        raise ValueError(
+            f"invalid participation_type: {participation_type}"
+        )
+
+    if verified_at is None:
+        return
+
+    try:
+        parsed = dt.datetime.fromisoformat(verified_at)
+    except ValueError as exc:
+        raise ValueError(
+            "verified_at must be an ISO 8601 datetime with timezone"
+        ) from exc
+
+    if parsed.tzinfo is None:
+        raise ValueError(
+            "verified_at must be an ISO 8601 datetime with timezone"
+        )
+
+
+def normalize_event_metadata(
+    event: dict[str, Any],
+) -> dict[str, Any]:
+    """
+    Legacy DynamoDB items do not have Issue #22 metadata.
+
+    Missing fields are supplemented only while loading/publishing old data.
+    Explicit invalid values are rejected instead of silently overwritten.
+    """
+    normalized = dict(event)
+
+    if "update_mode" not in normalized:
+        normalized["update_mode"] = LEGACY_UPDATE_MODE
+    if "participation_type" not in normalized:
+        normalized["participation_type"] = LEGACY_PARTICIPATION_TYPE
+    if "verified_at" not in normalized:
+        normalized["verified_at"] = None
+
+    validate_event_metadata(
+        update_mode=normalized["update_mode"],
+        participation_type=normalized["participation_type"],
+        verified_at=normalized["verified_at"],
+    )
+    return normalized
 
 
 @dataclass(frozen=True)
@@ -81,6 +164,18 @@ class ServiceEvent:
     status: str
     raw_note: Optional[str]
 
+    # Issue #22: イベント単位の取得・参加・確認メタデータ
+    update_mode: UpdateMode
+    participation_type: ParticipationType
+    verified_at: Optional[str]
+
     # DynamoDB DateIndex用
     gsi1_pk: str
     gsi1_sk: str
+
+    def __post_init__(self) -> None:
+        validate_event_metadata(
+            update_mode=self.update_mode,
+            participation_type=self.participation_type,
+            verified_at=self.verified_at,
+        )

--- a/kendo_keiko/pipeline.py
+++ b/kendo_keiko/pipeline.py
@@ -279,6 +279,9 @@ def normalize_events(
                 last_scraped_at=scraped_at,
                 status="active",
                 raw_note=raw.note,
+                update_mode="automatic",
+                participation_type="unknown",
+                verified_at=None,
                 gsi1_pk=gsi1_pk,
                 gsi1_sk=gsi1_sk,
             )

--- a/kendo_keiko/publication.py
+++ b/kendo_keiko/publication.py
@@ -10,6 +10,7 @@ from zoneinfo import ZoneInfo
 import boto3
 from boto3.dynamodb.conditions import Key
 
+from kendo_keiko.models import normalize_event_metadata
 from kendo_keiko.static_site import build_sitemap_xml, render_static_index
 
 
@@ -48,7 +49,10 @@ def query_events_from_dynamodb(
             kwargs["ExclusiveStartKey"] = last_evaluated_key
 
         response = table.query(**kwargs)
-        events.extend(response.get("Items", []))
+        events.extend(
+            normalize_event_metadata(item)
+            for item in response.get("Items", [])
+        )
         last_evaluated_key = response.get("LastEvaluatedKey")
         if not last_evaluated_key:
             break
@@ -71,16 +75,17 @@ def build_public_events_payload(
     region_name: str,
     from_date: str,
 ) -> dict[str, Any]:
+    normalized_events = [normalize_event_metadata(event) for event in events]
     return {
-        "schema_version": "public-events-0.1",
+        "schema_version": "public-events-0.2",
         "generated_at": dt.datetime.now(JST).isoformat(timespec="seconds"),
         "timezone": "Asia/Tokyo",
         "source": "dynamodb",
         "table_name": table_name,
         "region": region_name,
         "from_date": from_date,
-        "event_count": len(events),
-        "events": events,
+        "event_count": len(normalized_events),
+        "events": normalized_events,
     }
 
 

--- a/kendo_keiko/repository.py
+++ b/kendo_keiko/repository.py
@@ -37,6 +37,15 @@ def remove_none_values(item: dict) -> dict:
     return {key: value for key, value in item.items() if value is not None}
 
 
+def service_event_to_dynamodb_item(event: ServiceEvent) -> dict:
+    item = remove_none_values(asdict(event))
+
+    # verified_at=None means "not yet verified" and must be distinguishable
+    # from legacy items where the Issue #22 field itself does not exist.
+    item["verified_at"] = event.verified_at
+    return item
+
+
 def save_dynamodb(
     *,
     events: list[ServiceEvent],
@@ -52,4 +61,4 @@ def save_dynamodb(
 
     with table.batch_writer() as batch:
         for event in events:
-            batch.put_item(Item=remove_none_values(asdict(event)))
+            batch.put_item(Item=service_event_to_dynamodb_item(event))

--- a/query_dynamodb_events.py
+++ b/query_dynamodb_events.py
@@ -31,6 +31,8 @@ from zoneinfo import ZoneInfo
 import boto3
 from boto3.dynamodb.conditions import Key
 
+from kendo_keiko.models import normalize_event_metadata
+
 
 JST = ZoneInfo("Asia/Tokyo")
 
@@ -78,7 +80,10 @@ def query_events(
             kwargs["ExclusiveStartKey"] = last_evaluated_key
 
         response = table.query(**kwargs)
-        events.extend(response.get("Items", []))
+        events.extend(
+            normalize_event_metadata(item)
+            for item in response.get("Items", [])
+        )
 
         if limit and len(events) >= limit:
             events = events[:limit]
@@ -109,7 +114,7 @@ def save_json(
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     payload = {
-        "schema_version": "viewer-0.1",
+        "schema_version": "viewer-0.2",
         "generated_at": dt.datetime.now(JST).isoformat(timespec="seconds"),
         "timezone": "Asia/Tokyo",
         "source": "dynamodb",

--- a/tests/test_event_metadata.py
+++ b/tests/test_event_metadata.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import unittest
+
+from kendo_keiko.models import (
+    ServiceEvent,
+    normalize_event_metadata,
+)
+
+
+class EventMetadataTests(unittest.TestCase):
+    def make_event(self, **overrides) -> ServiceEvent:
+        values = {
+            "event_id": "event-1",
+            "organization_id": "test-org",
+            "organization_name": "テスト団体",
+            "event_type": "open_keiko",
+            "title": "通常稽古",
+            "event_date": "2026-08-01",
+            "weekday": "土",
+            "start_time": "19:00",
+            "end_time": "20:30",
+            "venue": "テスト武道館",
+            "area": "東京都",
+            "address": None,
+            "access": None,
+            "fee": None,
+            "application_required": None,
+            "source_url": "https://example.com/",
+            "source_type": "official_site",
+            "last_scraped_at": "2026-07-24T09:00:00+09:00",
+            "status": "active",
+            "raw_note": None,
+            "update_mode": "automatic",
+            "participation_type": "unknown",
+            "verified_at": None,
+            "gsi1_pk": "EVENT",
+            "gsi1_sk": "2026-08-01#19:00#test-org#event-1",
+        }
+        values.update(overrides)
+        return ServiceEvent(**values)
+
+    def test_supplements_legacy_event_metadata(self) -> None:
+        event = normalize_event_metadata({"event_id": "legacy-event"})
+
+        self.assertEqual("automatic", event["update_mode"])
+        self.assertEqual("unknown", event["participation_type"])
+        self.assertIsNone(event["verified_at"])
+
+    def test_preserves_explicit_event_metadata(self) -> None:
+        event = normalize_event_metadata(
+            {
+                "event_id": "manual-event",
+                "update_mode": "manual",
+                "participation_type": "contact_required",
+                "verified_at": "2026-07-24T09:00:00+09:00",
+            }
+        )
+
+        self.assertEqual("manual", event["update_mode"])
+        self.assertEqual("contact_required", event["participation_type"])
+        self.assertEqual(
+            "2026-07-24T09:00:00+09:00",
+            event["verified_at"],
+        )
+
+    def test_rejects_invalid_update_mode(self) -> None:
+        with self.assertRaisesRegex(ValueError, "invalid update_mode"):
+            self.make_event(update_mode="scheduled")
+
+    def test_rejects_invalid_participation_type(self) -> None:
+        with self.assertRaisesRegex(ValueError, "invalid participation_type"):
+            self.make_event(participation_type="open")
+
+    def test_rejects_verified_at_without_timezone(self) -> None:
+        with self.assertRaisesRegex(ValueError, "with timezone"):
+            self.make_event(verified_at="2026-07-24T09:00:00")

--- a/tests/test_lambda_static_publish.py
+++ b/tests/test_lambda_static_publish.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import unittest
 from unittest.mock import patch
 
@@ -70,6 +71,19 @@ class LambdaStaticPublishTests(unittest.TestCase):
             "application/json; charset=utf-8",
             objects["events.json"]["ContentType"],
         )
+        events_payload = json.loads(
+            objects["events.json"]["Body"].decode("utf-8")
+        )
+        self.assertEqual("public-events-0.2", events_payload["schema_version"])
+        self.assertEqual(
+            "automatic",
+            events_payload["events"][0]["update_mode"],
+        )
+        self.assertEqual(
+            "unknown",
+            events_payload["events"][0]["participation_type"],
+        )
+        self.assertIsNone(events_payload["events"][0]["verified_at"])
         self.assertEqual(
             "text/html; charset=utf-8",
             objects["index.html"]["ContentType"],

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -90,6 +90,9 @@ class PipelineTests(unittest.TestCase):
         self.assertEqual("東京都", event.area)
         self.assertEqual("500円 / 申込必須", event.fee)
         self.assertTrue(event.application_required)
+        self.assertEqual("automatic", event.update_mode)
+        self.assertEqual("unknown", event.participation_type)
+        self.assertIsNone(event.verified_at)
         self.assertTrue(event.event_id.startswith("test-org-20260801-1300-"))
 
         scraper.assert_called_once_with(

--- a/tests/test_publication.py
+++ b/tests/test_publication.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from kendo_keiko.publication import (
+    build_public_events_payload,
+    query_events_from_dynamodb,
+)
+
+
+class FakeTable:
+    def __init__(self, responses: list[dict]) -> None:
+        self.responses = list(responses)
+        self.calls: list[dict] = []
+
+    def query(self, **kwargs) -> dict:
+        self.calls.append(kwargs)
+        return self.responses.pop(0)
+
+
+class FakeDynamoDbResource:
+    def __init__(self, table: FakeTable) -> None:
+        self.table = table
+
+    def Table(self, table_name: str) -> FakeTable:
+        return self.table
+
+
+class PublicationTests(unittest.TestCase):
+    def test_query_supplements_legacy_metadata_and_sorts_events(self) -> None:
+        table = FakeTable(
+            [
+                {
+                    "Items": [
+                        {
+                            "event_id": "event-2",
+                            "organization_id": "org-b",
+                            "event_date": "2026-08-02",
+                            "start_time": "19:00",
+                        },
+                        {
+                            "event_id": "event-1",
+                            "organization_id": "org-a",
+                            "event_date": "2026-08-01",
+                            "start_time": "09:00",
+                        },
+                    ]
+                }
+            ]
+        )
+        resource = FakeDynamoDbResource(table)
+
+        with patch(
+            "kendo_keiko.publication.boto3.resource",
+            return_value=resource,
+        ):
+            events = query_events_from_dynamodb(
+                table_name="KendoKeikoEvents",
+                region_name="ap-northeast-1",
+                from_date="2026-07-24",
+            )
+
+        self.assertEqual(["event-1", "event-2"], [e["event_id"] for e in events])
+        for event in events:
+            self.assertEqual("automatic", event["update_mode"])
+            self.assertEqual("unknown", event["participation_type"])
+            self.assertIsNone(event["verified_at"])
+
+    def test_payload_preserves_explicit_manual_metadata(self) -> None:
+        payload = build_public_events_payload(
+            events=[
+                {
+                    "event_id": "manual-event",
+                    "update_mode": "manual",
+                    "participation_type": "members_only",
+                    "verified_at": "2026-07-24T09:00:00+09:00",
+                }
+            ],
+            table_name="KendoKeikoEvents",
+            region_name="ap-northeast-1",
+            from_date="2026-07-24",
+        )
+
+        event = payload["events"][0]
+        self.assertEqual("public-events-0.2", payload["schema_version"])
+        self.assertEqual("manual", event["update_mode"])
+        self.assertEqual("members_only", event["participation_type"])
+        self.assertEqual("2026-07-24T09:00:00+09:00", event["verified_at"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from kendo_keiko.models import ServiceEvent
+from kendo_keiko.repository import save_dynamodb
+
+
+class FakeBatchWriter:
+    def __init__(self) -> None:
+        self.items: list[dict] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        return None
+
+    def put_item(self, *, Item: dict) -> None:
+        self.items.append(Item)
+
+
+class FakeTable:
+    def __init__(self) -> None:
+        self.writer = FakeBatchWriter()
+
+    def batch_writer(self) -> FakeBatchWriter:
+        return self.writer
+
+
+class FakeDynamoDbResource:
+    def __init__(self, table: FakeTable) -> None:
+        self.table = table
+
+    def Table(self, table_name: str) -> FakeTable:
+        return self.table
+
+
+class RepositoryTests(unittest.TestCase):
+    def make_event(self) -> ServiceEvent:
+        return ServiceEvent(
+            event_id="event-1",
+            organization_id="test-org",
+            organization_name="テスト団体",
+            event_type="open_keiko",
+            title="通常稽古",
+            event_date="2026-08-01",
+            weekday="土",
+            start_time="19:00",
+            end_time="20:30",
+            venue="テスト武道館",
+            area="東京都",
+            address=None,
+            access=None,
+            fee=None,
+            application_required=None,
+            source_url="https://example.com/",
+            source_type="official_site",
+            last_scraped_at="2026-07-24T09:00:00+09:00",
+            status="active",
+            raw_note=None,
+            update_mode="automatic",
+            participation_type="unknown",
+            verified_at=None,
+            gsi1_pk="EVENT",
+            gsi1_sk="2026-08-01#19:00#test-org#event-1",
+        )
+
+    def test_saves_event_metadata_and_preserves_null_verified_at(self) -> None:
+        table = FakeTable()
+        resource = FakeDynamoDbResource(table)
+
+        with patch(
+            "kendo_keiko.repository.boto3.resource",
+            return_value=resource,
+        ):
+            save_dynamodb(
+                events=[self.make_event()],
+                table_name="KendoKeikoEvents",
+                region="ap-northeast-1",
+            )
+
+        self.assertEqual(1, len(table.writer.items))
+        item = table.writer.items[0]
+        self.assertEqual("automatic", item["update_mode"])
+        self.assertEqual("unknown", item["participation_type"])
+        self.assertIn("verified_at", item)
+        self.assertIsNone(item["verified_at"])
+        self.assertNotIn("address", item)

--- a/tests/test_scraper_worker.py
+++ b/tests/test_scraper_worker.py
@@ -48,6 +48,9 @@ class ScraperWorkerTests(unittest.TestCase):
             last_scraped_at="2026-07-22T17:00:00+09:00",
             status="active",
             raw_note=None,
+            update_mode="automatic",
+            participation_type="unknown",
+            verified_at=None,
             gsi1_pk="EVENT",
             gsi1_sk=(
                 "2026-08-01#19:00#test-org#"


### PR DESCRIPTION
## 概要

Issue #22「稽古会情報の取得方式・参加条件・確認日をイベント単位で管理する」に対応します。

稽古会イベントごとに、取得方式・参加条件・最終確認日時を管理できるようにしました。

## 変更内容

- `ServiceEvent` に以下の項目を追加
  - `update_mode`
  - `participation_type`
  - `verified_at`
- 自動スクレイピングで取得したイベントに以下を設定
  - `update_mode: automatic`
  - `participation_type: unknown`
  - `verified_at: null`
- `update_mode` と `participation_type` の値をバリデーション
- `verified_at` をタイムゾーン付きISO 8601形式でバリデーション
- DynamoDBへの保存・読み込みに対応
- `events.json` の出力に新しいメタデータを追加
- 既存のDynamoDBイベントに対する後方互換処理を追加
- データモデルのドキュメントを更新
- JSONスキーマバージョンを更新

## 後方互換性

Issue #22以前に保存されたイベントには新しい属性が存在しないため、読み込み時に以下の値を補完します。

```json
{
  "update_mode": "automatic",
  "participation_type": "unknown",
  "verified_at": null
}
```

明示的に不正な値が保存されている場合は、黙って補正せずエラーにします。

## 今回含めないもの

以下はIssue #26で対応します。

- 参加条件のバッジ表示
- 参加条件による絞り込み
- 最終確認日の画面表示

## テスト

```text
Ran 49 tests in 0.034s

OK
```

以下も確認済みです。

- Lambdaパッケージのビルド成功
- Lambda ZIP内のimport検査成功
- ZIP内容検査成功

Closes #22
