### PR TITLE
feat: add manual event for 剣縁

### DIFF
--- a/data/manual_events.json
+++ b/data/manual_events.json
@@ -196,6 +196,34 @@
       "review_due_at": "2026-08-24",
       "gsi1_pk": "EVENT",
       "gsi1_sk": "2026-08-27#19:30#magokorokai#magokorokai-20260827-1930-68817322"
+    },
+    {
+      "event_id": "kenen-20260830-0930-fcace356",
+      "organization_id": "kenen",
+      "organization_name": "剣縁",
+      "event_type": "open_keiko",
+      "title": "剣縁の集い",
+      "event_date": "2026-08-30",
+      "weekday": "日",
+      "start_time": "09:30",
+      "end_time": "10:30",
+      "venue": "渋谷区スポーツセンター 第1武道場",
+      "area": "東京都",
+      "address": "東京都渋谷区西原1-40-18",
+      "access": "京王新線「幡ヶ谷駅」南口から徒歩約6分、小田急線「代々木上原駅」から徒歩約15分",
+      "fee": "1,000円（税込）／名、剣縁法人・個人会員は無料",
+      "application_required": true,
+      "source_url": "https://kenen.jp/event/ken-en-no-tsudoi-1st",
+      "source_type": "official_site",
+      "last_scraped_at": "2026-07-26T19:26:00+09:00",
+      "status": "active",
+      "raw_note": "エントリー締切は2026年8月19日。最少催行人数5名。申込み: https://forms.gle/WCAsBBiikFLFsqQr8。子どもの参加は保護者が剣縁会員に入会し、当日同伴することが必要。",
+      "update_mode": "manual",
+      "participation_type": "registration_required",
+      "verified_at": "2026-07-26T19:26:00+09:00",
+      "review_due_at": "2026-08-20",
+      "gsi1_pk": "EVENT",
+      "gsi1_sk": "2026-08-30#09:30#kenen#kenen-20260830-0930-fcace356"
     }
   ]
 }

--- a/data/organizations.json
+++ b/data/organizations.json
@@ -82,5 +82,17 @@
     "event_type": "open_keiko",
     "notes": "公式サイトのカレンダーを管理者が確認し、手動登録",
     "public_description": "さいたま市見沼区の春里中学校武道場で開催される眞心会の稽古予定を掲載しています。"
+  },
+  {
+    "organization_id": "kenen",
+    "name": "剣縁",
+    "area": "全国",
+    "website_url": "https://kenen.jp/",
+    "source_type": "official_site",
+    "scraper_type": "manual",
+    "scraper_enabled": false,
+    "event_type": "open_keiko",
+    "notes": "公式サイトのイベント情報を管理者が確認し、手動登録",
+    "public_description": "剣道家の交流サイト「剣縁」が開催する稽古会の予定を掲載しています。"
   }
 ]

--- a/public/index.html
+++ b/public/index.html
@@ -827,6 +827,12 @@
           <p>さいたま市見沼区の春里中学校武道場で開催される眞心会の稽古予定を掲載しています。</p>
           <p class="organization-link"><a href="https://magokorokai.crayonsite.com/" target="_blank" rel="noopener noreferrer">公式サイトを確認</a></p>
         </li>
+        <li class="organization-item">
+          <h3>剣縁</h3>
+          <p class="organization-area">主な地域: 全国</p>
+          <p>剣道家の交流サイト「剣縁」が開催する稽古会の予定を掲載しています。</p>
+          <p class="organization-link"><a href="https://kenen.jp/" target="_blank" rel="noopener noreferrer">公式サイトを確認</a></p>
+        </li>
       </ul>
       <p class="organization-source-note">
         日程や参加条件が変更される場合があります。参加前に必ず主催団体の公式情報をご確認ください。


### PR DESCRIPTION
## 概要

剣縁公式サイトで案内されている「剣縁の集い」を、手動イベントとして1件追加しました。

Closes #39

## 情報源

- https://kenen.jp/event/ken-en-no-tsudoi-1st

## 登録内容

- 団体: 剣縁
- 開催日: 2026年8月30日
- 時間: 09:30〜10:30
- 会場: 渋谷区スポーツセンター 第1武道場
- 参加条件: 事前登録必須
- 参加費: 1,000円（税込）／名
- 剣縁法人・個人会員は無料
- エントリー締切: 2026年8月19日
- 次回確認期限: 2026年8月20日
- update_mode: manual
- participation_type: registration_required

## 変更内容

- data/organizations.json に剣縁を追加
- data/manual_events.json にイベントを1件追加
- 掲載団体セクションを再生成

## テスト

- 64件成功
- Lambda ZIPビルド成功
- data/manual_events.json の同梱確認済み
- data/organizations.json の同梱確認済み
