### PR TITLE
feat: 稽古会カードに参加条件と情報確認状況を表示する

### DIFF
--- a/kendo_keiko/static_site.py
+++ b/kendo_keiko/static_site.py
@@ -14,6 +14,15 @@ EVENT_COUNT_END = "<!-- EVENT_COUNT_END -->"
 EVENT_CARDS_START = "<!-- EVENT_CARDS_START -->"
 EVENT_CARDS_END = "<!-- EVENT_CARDS_END -->"
 
+PARTICIPATION_LABELS = {
+    "anyone": "一般参加可",
+    "contact_required": "事前連絡",
+    "registration_required": "申込必須",
+    "invitation_required": "招待制",
+    "members_only": "会員限定",
+    "unknown": "公式情報を確認",
+}
+
 
 def safe_http_url(value: object) -> str:
     if not value:
@@ -54,6 +63,88 @@ def format_event_time(event: dict[str, Any]) -> str:
     return "時間未定"
 
 
+def _iso_date(value: object) -> dt.date | None:
+    text = _text(value)
+    if len(text) < 10:
+        return None
+
+    try:
+        return dt.date.fromisoformat(text[:10])
+    except ValueError:
+        return None
+
+
+def participation_type_for_display(event: dict[str, Any]) -> str:
+    participation_type = _text(
+        event.get("participation_type"),
+        "unknown",
+    )
+    if participation_type not in PARTICIPATION_LABELS:
+        return "unknown"
+    if (
+        event.get("application_required") is False
+        and participation_type == "registration_required"
+    ):
+        return "unknown"
+    return participation_type
+
+
+def render_event_status(
+    event: dict[str, Any],
+    *,
+    reference_date: dt.date | None = None,
+) -> list[str]:
+    participation_type = participation_type_for_display(event)
+    participation_label = PARTICIPATION_LABELS[participation_type]
+
+    lines = [
+        (
+            '          <div class="event-status" '
+            'aria-label="参加条件と情報確認状況">'
+        ),
+        (
+            '            <span class="status-badge '
+            f'status-badge--{participation_type}">'
+            f'{escape(participation_label, quote=True)}</span>'
+        ),
+    ]
+
+    if (
+        event.get("application_required") is True
+        and participation_type != "registration_required"
+    ):
+        lines.append(
+            '            <span class="status-badge '
+            'status-badge--registration_required">申込必須</span>'
+        )
+
+    verified_date = _iso_date(event.get("verified_at"))
+    if verified_date is not None:
+        verification_text = f"最終確認: {verified_date.isoformat()}"
+    elif _text(event.get("update_mode"), "automatic") == "automatic":
+        verification_text = "自動取得（未確認）"
+    else:
+        verification_text = "最終確認日なし"
+
+    lines.append(
+        '            <span class="verification-status">'
+        f'{escape(verification_text, quote=True)}</span>'
+    )
+
+    review_due_at = _iso_date(event.get("review_due_at"))
+    if (
+        reference_date is not None
+        and review_due_at is not None
+        and review_due_at < reference_date
+    ):
+        lines.append(
+            '            <span class="status-warning">確認期限超過</span>'
+        )
+
+    lines.append("          </div>")
+    return lines
+
+
 def sort_events(events: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
     return sorted(
         events,
@@ -66,7 +157,11 @@ def sort_events(events: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
     )
 
 
-def render_event_card(event: dict[str, Any]) -> str:
+def render_event_card(
+    event: dict[str, Any],
+    *,
+    reference_date: dt.date | None = None,
+) -> str:
     lines = [
         '        <article class="card">',
         f'          <div class="date">{escape(format_event_date(event), quote=True)}</div>',
@@ -83,6 +178,12 @@ def render_event_card(event: dict[str, Any]) -> str:
             f'          <div class="title">{escape(title, quote=True)}</div>'
         )
 
+    lines.extend(
+        render_event_status(
+            event,
+            reference_date=reference_date,
+        )
+    )
     lines.extend(
         [
             (
@@ -133,11 +234,18 @@ def render_event_card(event: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-def render_event_cards(events: list[dict[str, Any]]) -> str:
+def render_event_cards(
+    events: list[dict[str, Any]],
+    *,
+    reference_date: dt.date | None = None,
+) -> str:
     if not events:
         return '        <div class="empty">現在掲載中の稽古会はありません。</div>'
 
-    return "\n".join(render_event_card(event) for event in events)
+    return "\n".join(
+        render_event_card(event, reference_date=reference_date)
+        for event in events
+    )
 
 
 def _replace_marked_content(
@@ -185,6 +293,7 @@ def render_static_index(
 
     events = sort_events(events)
     generated_at = _text(payload.get("generated_at"), "-")
+    reference_date = _iso_date(generated_at)
     event_count = len(events)
 
     html = _replace_marked_content(
@@ -209,7 +318,10 @@ def render_static_index(
         html,
         start_marker=EVENT_CARDS_START,
         end_marker=EVENT_CARDS_END,
-        content=render_event_cards(events),
+        content=render_event_cards(
+            events,
+            reference_date=reference_date,
+        ),
         indent="        ",
     )
     return html

--- a/public/index.html
+++ b/public/index.html
@@ -335,6 +335,7 @@
 
     .card .org,
     .card .title,
+    .card .event-status,
     .card .row {
       grid-column: 2;
       min-width: 0;
@@ -357,6 +358,65 @@
       font-weight: 600;
       line-height: 1.6;
       overflow-wrap: anywhere;
+    }
+
+    .card .event-status {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 7px 10px;
+      margin: 0 0 14px;
+    }
+
+    .status-badge,
+    .status-warning {
+      display: inline-flex;
+      align-items: center;
+      min-height: 26px;
+      padding: 3px 9px;
+      border: 1px solid var(--line-strong);
+      font-size: 0.75rem;
+      font-weight: 700;
+      line-height: 1.35;
+      letter-spacing: 0.02em;
+    }
+
+    .status-badge--anyone {
+      color: #28563f;
+      background: rgba(40, 86, 63, 0.08);
+      border-color: rgba(40, 86, 63, 0.42);
+    }
+
+    .status-badge--contact_required,
+    .status-badge--registration_required {
+      color: var(--accent);
+      background: rgba(140, 29, 36, 0.07);
+      border-color: rgba(140, 29, 36, 0.42);
+    }
+
+    .status-badge--invitation_required,
+    .status-badge--members_only {
+      color: var(--ink);
+      background: rgba(31, 30, 28, 0.06);
+      border-color: rgba(31, 30, 28, 0.34);
+    }
+
+    .status-badge--unknown {
+      color: var(--muted);
+      background: rgba(108, 104, 98, 0.06);
+      border-color: rgba(108, 104, 98, 0.34);
+    }
+
+    .verification-status {
+      color: var(--muted);
+      font-size: 0.76rem;
+      line-height: 1.5;
+    }
+
+    .status-warning {
+      color: var(--accent);
+      background: rgba(140, 29, 36, 0.07);
+      border-color: rgba(140, 29, 36, 0.48);
     }
 
     .card .row {
@@ -878,7 +938,17 @@
   </footer>
 
   <script>
+    const PARTICIPATION_LABELS = Object.freeze({
+      anyone: "一般参加可",
+      contact_required: "事前連絡",
+      registration_required: "申込必須",
+      invitation_required: "招待制",
+      members_only: "会員限定",
+      unknown: "公式情報を確認",
+    });
+
     let allEvents = [];
+    let generatedDate = "";
 
     function escapeHtml(value) {
       if (value === null || value === undefined) return "";
@@ -901,6 +971,83 @@
       }
       if (event.start_time) return event.start_time;
       return "時間未定";
+    }
+
+    function isoDate(value) {
+      const text = value === null || value === undefined
+        ? ""
+        : String(value).trim();
+      const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(text);
+      if (!match) return "";
+
+      const [, year, month, day] = match;
+      const parsed = new Date(`${year}-${month}-${day}T00:00:00Z`);
+      if (
+        parsed.getUTCFullYear() !== Number(year)
+        || parsed.getUTCMonth() + 1 !== Number(month)
+        || parsed.getUTCDate() !== Number(day)
+      ) {
+        return "";
+      }
+      return `${year}-${month}-${day}`;
+    }
+
+    function participationTypeForDisplay(event) {
+      const participationType = Object.prototype.hasOwnProperty.call(
+        PARTICIPATION_LABELS,
+        event.participation_type
+      )
+        ? event.participation_type
+        : "unknown";
+
+      if (
+        event.application_required === false
+        && participationType === "registration_required"
+      ) {
+        return "unknown";
+      }
+      return participationType;
+    }
+
+    function eventStatusHtml(event) {
+      const participationType = participationTypeForDisplay(event);
+      const participationLabel = PARTICIPATION_LABELS[participationType];
+      const applicationBadge = (
+        event.application_required === true
+        && participationType !== "registration_required"
+      )
+        ? '<span class="status-badge status-badge--registration_required">申込必須</span>'
+        : "";
+
+      const verifiedDate = isoDate(event.verified_at);
+      let verificationText;
+      if (verifiedDate) {
+        verificationText = `最終確認: ${verifiedDate}`;
+      } else if ((event.update_mode || "automatic") === "automatic") {
+        verificationText = "自動取得（未確認）";
+      } else {
+        verificationText = "最終確認日なし";
+      }
+
+      const reviewDueAt = isoDate(event.review_due_at);
+      const warning = (
+        reviewDueAt
+        && generatedDate
+        && reviewDueAt < generatedDate
+      )
+        ? '<span class="status-warning">確認期限超過</span>'
+        : "";
+
+      return `
+        <div class="event-status" aria-label="参加条件と情報確認状況">
+          <span class="status-badge status-badge--${participationType}">
+            ${escapeHtml(participationLabel)}
+          </span>
+          ${applicationBadge}
+          <span class="verification-status">${escapeHtml(verificationText)}</span>
+          ${warning}
+        </div>
+      `;
     }
 
     function renderOrganizations(events) {
@@ -978,6 +1125,7 @@
           <div class="date">${escapeHtml(formatDate(event))}</div>
           <div class="org">${escapeHtml(event.organization_name || "")}</div>
           ${title}
+          ${eventStatusHtml(event)}
           <div class="row"><span class="label">時間</span>${escapeHtml(formatTime(event))}</div>
           <div class="row"><span class="label">会場</span>${escapeHtml(event.venue || "未取得")}</div>
           <div class="row"><span class="label">エリア</span>${escapeHtml(event.area || "未設定")}</div>
@@ -999,6 +1147,7 @@
 
         const payload = await response.json();
         allEvents = payload.events || [];
+        generatedDate = isoDate(payload.generated_at);
 
         document.getElementById("meta").textContent =
           `生成日時: ${payload.generated_at || "-"} / 件数: ${payload.event_count ?? allEvents.length}`;

--- a/tests/test_static_site.py
+++ b/tests/test_static_site.py
@@ -5,7 +5,9 @@ import unittest
 from pathlib import Path
 
 from kendo_keiko.static_site import (
+    PARTICIPATION_LABELS,
     build_sitemap_xml,
+    render_event_card,
     render_static_index,
 )
 
@@ -70,6 +72,106 @@ class StaticSiteTests(unittest.TestCase):
         self.assertIn("剣道稽古ナビ", rendered)
         self.assertIn("https://kendo-keiko.com/ogp.png", rendered)
         self.assertIn('href="/favicon.svg"', rendered)
+
+    def test_renders_all_participation_labels(self) -> None:
+        base_event = {
+            "event_date": "2026-08-01",
+            "organization_name": "テスト団体",
+            "application_required": None,
+            "update_mode": "automatic",
+        }
+
+        for participation_type, label in PARTICIPATION_LABELS.items():
+            with self.subTest(participation_type=participation_type):
+                card = render_event_card(
+                    {
+                        **base_event,
+                        "participation_type": participation_type,
+                    }
+                )
+                self.assertIn(label, card)
+                self.assertIn(
+                    f"status-badge--{participation_type}",
+                    card,
+                )
+
+    def test_reconciles_application_required_with_participation(self) -> None:
+        application_required = render_event_card(
+            {
+                "event_date": "2026-08-01",
+                "organization_name": "テスト団体",
+                "participation_type": "contact_required",
+                "application_required": True,
+                "update_mode": "manual",
+                "verified_at": "2026-07-20T09:30:00+09:00",
+            }
+        )
+        self.assertIn("事前連絡", application_required)
+        self.assertIn("申込必須", application_required)
+
+        conflicting_not_required = render_event_card(
+            {
+                "event_date": "2026-08-01",
+                "organization_name": "テスト団体",
+                "participation_type": "registration_required",
+                "application_required": False,
+                "update_mode": "manual",
+                "verified_at": "2026-07-20T09:30:00+09:00",
+            }
+        )
+        self.assertIn("公式情報を確認", conflicting_not_required)
+        self.assertNotIn("申込必須", conflicting_not_required)
+
+    def test_renders_verification_and_review_status(self) -> None:
+        card = render_event_card(
+            {
+                "event_date": "2026-08-01",
+                "organization_name": "テスト団体",
+                "participation_type": "contact_required",
+                "application_required": False,
+                "update_mode": "manual",
+                "verified_at": "2026-07-20T09:30:00+09:00",
+                "review_due_at": "2026-07-20",
+            },
+            reference_date=dt.date(2026, 7, 21),
+        )
+
+        self.assertIn("事前連絡", card)
+        self.assertIn("最終確認: 2026-07-20", card)
+        self.assertIn("確認期限超過", card)
+
+    def test_automatic_event_without_verified_at_is_marked_unverified(
+        self,
+    ) -> None:
+        card = render_event_card(
+            {
+                "event_date": "2026-08-01",
+                "organization_name": "テスト団体",
+                "participation_type": "anyone",
+                "application_required": False,
+                "update_mode": "automatic",
+                "verified_at": None,
+                "review_due_at": None,
+            }
+        )
+
+        self.assertIn("自動取得（未確認）", card)
+        self.assertNotIn("最終確認:", card)
+
+    def test_client_renderer_contains_same_status_labels(self) -> None:
+        for participation_type, label in PARTICIPATION_LABELS.items():
+            with self.subTest(participation_type=participation_type):
+                self.assertIn(
+                    f'{participation_type}: "{label}"',
+                    self.template,
+                )
+        self.assertIn("${eventStatusHtml(event)}", self.template)
+        self.assertIn("自動取得（未確認）", self.template)
+        self.assertIn("確認期限超過", self.template)
+        self.assertIn(
+            "参加前には必ず主催者の公式情報をご確認ください",
+            self.template,
+        )
 
     def test_rendering_is_idempotent(self) -> None:
         once = render_static_index(self.template, self.payload)


### PR DESCRIPTION
## 概要

稽古会カードに、参加条件と情報確認状況を表示します。

Closes #45

## 変更内容

- 参加条件を文字付きバッジで表示
  - 一般参加可
  - 事前連絡
  - 申込必須
  - 招待制
  - 会員限定
  - 公式情報を確認
- `verified_at` がある場合は最終確認日を表示
- 未確認の自動取得情報を、確認済みと誤認させない文言で表示
- `review_due_at` 超過時に警告を表示
- `application_required` との矛盾を考慮
- 静的HTMLとJavaScript再描画で表示・判定を統一
- 色だけでなく文字でも状態を識別可能にした
- スマートフォンで折り返せる表示にした

## 対象外

- 日付・地域・参加条件による絞り込み（#46）
- Googleカレンダー追加（#11）
- Instagram関連作業（#49）

## テスト

- `python -m unittest discover -s tests -v`
- 71 tests passed
- `git diff --check` 成功
