### PR TITLE
feat: 自動取得団体に参加条件の既定値を設定する

### DIFF
--- a/data/organizations.json
+++ b/data/organizations.json
@@ -9,7 +9,9 @@
     "scraper_enabled": true,
     "event_type": "open_keiko",
     "notes": "公式サイトのSCHEDULEから取得",
-    "public_description": "東京都内で活動する社会人剣道サークルkentの稽古予定を掲載しています。"
+    "public_description": "東京都内で活動する社会人剣道サークルkentの稽古予定を掲載しています。",
+    "default_participation_type": "anyone",
+    "default_application_required": false
   },
   {
     "organization_id": "kenkyukai",
@@ -21,7 +23,9 @@
     "scraper_enabled": true,
     "event_type": "open_keiko",
     "notes": "公式サイトの新着情報から取得",
-    "public_description": "剣究会が東京都内で開催する剣道稽古会の予定を掲載しています。"
+    "public_description": "剣究会が東京都内で開催する剣道稽古会の予定を掲載しています。",
+    "default_participation_type": "anyone",
+    "default_application_required": false
   },
   {
     "organization_id": "kenbokukai",

--- a/kendo_keiko/models.py
+++ b/kendo_keiko/models.py
@@ -109,6 +109,22 @@ class Organization:
     event_type: str
     notes: Optional[str] = None
     public_description: Optional[str] = None
+    default_participation_type: ParticipationType = "unknown"
+    default_application_required: Optional[bool] = None
+
+    def __post_init__(self) -> None:
+        if self.default_participation_type not in VALID_PARTICIPATION_TYPES:
+            raise ValueError(
+                "invalid default_participation_type: "
+                f"{self.default_participation_type}"
+            )
+        if (
+            self.default_application_required is not None
+            and not isinstance(self.default_application_required, bool)
+        ):
+            raise ValueError(
+                "default_application_required must be bool or None"
+            )
 
 
 @dataclass(frozen=True)

--- a/kendo_keiko/pipeline.py
+++ b/kendo_keiko/pipeline.py
@@ -8,6 +8,7 @@ from typing import Iterable, Optional
 
 from kendo_keiko.models import (
     Organization,
+    ParticipationType,
     RawScrapedEvent,
     ServiceEvent,
 )
@@ -221,6 +222,33 @@ def infer_application_required(
     return None
 
 
+
+def resolve_participation_metadata(
+    *,
+    org: Organization,
+    note: Optional[str],
+    title: Optional[str],
+) -> tuple[Optional[bool], ParticipationType]:
+    """Resolve event metadata, preferring event text over org defaults."""
+    application_required = infer_application_required(note, title)
+    if application_required is None:
+        application_required = org.default_application_required
+
+    participation_type = org.default_participation_type
+    if (
+        application_required is True
+        and participation_type
+        in {"anyone", "contact_required", "unknown"}
+    ):
+        participation_type = "registration_required"
+    elif (
+        application_required is False
+        and participation_type == "registration_required"
+    ):
+        participation_type = "unknown"
+
+    return application_required, participation_type
+
 def normalize_events(
     raw_events: Iterable[RawScrapedEvent],
     organizations: list[Organization],
@@ -253,6 +281,14 @@ def normalize_events(
             organization_id=org.organization_id,
             event_id=event_id,
         )
+        (
+            application_required,
+            participation_type,
+        ) = resolve_participation_metadata(
+            org=org,
+            note=raw.note,
+            title=raw.title,
+        )
 
         service_events.append(
             ServiceEvent(
@@ -270,17 +306,14 @@ def normalize_events(
                 address=None,
                 access=raw.access,
                 fee=extract_fee(raw.note),
-                application_required=infer_application_required(
-                    raw.note,
-                    raw.title,
-                ),
+                application_required=application_required,
                 source_url=raw.source_url,
                 source_type=org.source_type,
                 last_scraped_at=scraped_at,
                 status="active",
                 raw_note=raw.note,
                 update_mode="automatic",
-                participation_type="unknown",
+                participation_type=participation_type,
                 verified_at=None,
                 gsi1_pk=gsi1_pk,
                 gsi1_sk=gsi1_sk,

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -3,7 +3,8 @@ import unittest
 from unittest.mock import Mock, patch
 
 from kendo_keiko.models import Organization, RawScrapedEvent
-from kendo_keiko.pipeline import run_pipeline
+from kendo_keiko.pipeline import normalize_events, run_pipeline
+from kendo_keiko.repository import load_organizations
 from kendo_keiko.scrapers import SCRAPER_REGISTRY
 
 
@@ -91,7 +92,10 @@ class PipelineTests(unittest.TestCase):
         self.assertEqual("500円 / 申込必須", event.fee)
         self.assertTrue(event.application_required)
         self.assertEqual("automatic", event.update_mode)
-        self.assertEqual("unknown", event.participation_type)
+        self.assertEqual(
+            "registration_required",
+            event.participation_type,
+        )
         self.assertIsNone(event.verified_at)
         self.assertTrue(event.event_id.startswith("test-org-20260801-1300-"))
 
@@ -100,6 +104,104 @@ class PipelineTests(unittest.TestCase):
             debug=False,
         )
 
+
+
+    def test_uses_organization_participation_defaults(self) -> None:
+        organization = Organization(
+            organization_id="default-org",
+            name="既定値団体",
+            area="東京都",
+            website_url="https://example.com/",
+            source_type="official_site",
+            scraper_type="test-scraper",
+            scraper_enabled=True,
+            event_type="open_keiko",
+            default_participation_type="anyone",
+            default_application_required=False,
+        )
+        raw_event = RawScrapedEvent(
+            group="既定値団体",
+            title="通常稽古",
+            date="2026-08-01",
+            weekday="土",
+            start_time="13:00",
+            end_time="15:00",
+            venue="テスト武道館",
+            area=None,
+            access=None,
+            note=None,
+            source_url="https://example.com/event",
+            event_type="open_keiko",
+        )
+
+        event = normalize_events(
+            [raw_event],
+            [organization],
+            "2026-07-30T09:00:00+09:00",
+        )[0]
+
+        self.assertEqual("anyone", event.participation_type)
+        self.assertFalse(event.application_required)
+        self.assertIsNone(event.verified_at)
+
+    def test_event_application_text_overrides_organization_default(
+        self,
+    ) -> None:
+        organization = Organization(
+            organization_id="default-org",
+            name="既定値団体",
+            area="東京都",
+            website_url="https://example.com/",
+            source_type="official_site",
+            scraper_type="test-scraper",
+            scraper_enabled=True,
+            event_type="open_keiko",
+            default_participation_type="anyone",
+            default_application_required=False,
+        )
+        raw_event = RawScrapedEvent(
+            group="既定値団体",
+            title="特別稽古",
+            date="2026-08-01",
+            weekday="土",
+            start_time="13:00",
+            end_time="15:00",
+            venue="テスト武道館",
+            area=None,
+            access=None,
+            note="申込必須",
+            source_url="https://example.com/event",
+            event_type="open_keiko",
+        )
+
+        event = normalize_events(
+            [raw_event],
+            [organization],
+            "2026-07-30T09:00:00+09:00",
+        )[0]
+
+        self.assertEqual(
+            "registration_required",
+            event.participation_type,
+        )
+        self.assertTrue(event.application_required)
+
+    def test_kent_and_kenkyukai_default_to_anyone(self) -> None:
+        organizations = {
+            organization.organization_id: organization
+            for organization in load_organizations()
+        }
+
+        for organization_id in ("kent", "kenkyukai"):
+            with self.subTest(organization_id=organization_id):
+                organization = organizations[organization_id]
+                self.assertEqual(
+                    "anyone",
+                    organization.default_participation_type,
+                )
+                self.assertFalse(
+                    organization.default_application_required
+                )
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 概要

自動取得団体に参加条件の既定値を設定し、kentと剣究会を「一般参加可」として表示します。

Closes #51

## 変更内容

- Organizationに参加条件の既定値を追加
- Organizationに申込要否の既定値を追加
- kentを一般参加可・申込不要に設定
- 剣究会を一般参加可・申込不要に設定
- 個別イベントから申込要否を判定できる場合はイベント内容を優先
- 「申込必須」のイベントは registration_required として正規化
- 自動取得イベントの verified_at は変更せず、未確認表示を維持

## 対象外

- カードUIの変更
- 絞り込み機能
- 他団体の参加条件変更
- スクレイパー固有の取得処理変更

## テスト

- python -m unittest discover -s tests -v
- 74 tests passed
- git diff --check 成功
