### PR TITLE
埼玉県剣道連盟の月例稽古会を自動取得する

### DIFF
--- a/data/organizations.json
+++ b/data/organizations.json
@@ -76,6 +76,18 @@
     "public_description": "神奈川県剣道連盟が神奈川県立武道館で開催する一般合同稽古会・女子合同稽古会の予定を掲載しています。"
   },
   {
+    "organization_id": "saitama",
+    "name": "埼玉県剣道連盟",
+    "area": "埼玉県",
+    "website_url": "https://www.saitama-kendo.or.jp/plugin/calendars/index/11/229",
+    "source_type": "official_site",
+    "scraper_type": "saitama",
+    "scraper_enabled": true,
+    "event_type": "federation_keiko",
+    "notes": "公式の年間行事予定カレンダーから月例稽古会を取得",
+    "public_description": "埼玉県剣道連盟が埼玉県内で開催する月例稽古会の予定を掲載しています。"
+  },
+  {
     "organization_id": "magokorokai",
     "name": "眞心会",
     "area": "埼玉県",

--- a/kendo_keiko/models.py
+++ b/kendo_keiko/models.py
@@ -161,6 +161,7 @@ class RawScrapedEvent:
     note: Optional[str]
     source_url: str
     event_type: str
+    participation_type: Optional[ParticipationType] = None
 
 
 @dataclass(frozen=True)

--- a/kendo_keiko/pipeline.py
+++ b/kendo_keiko/pipeline.py
@@ -59,6 +59,7 @@ def event_score(event: RawScrapedEvent) -> int:
         event.access,
         event.note,
         event.source_url,
+        event.participation_type,
     ):
         if value:
             score += 1
@@ -228,13 +229,18 @@ def resolve_participation_metadata(
     org: Organization,
     note: Optional[str],
     title: Optional[str],
+    event_participation_type: Optional[ParticipationType] = None,
 ) -> tuple[Optional[bool], ParticipationType]:
-    """Resolve event metadata, preferring event text over org defaults."""
+    """Resolve event metadata, preferring event values over org defaults."""
     application_required = infer_application_required(note, title)
     if application_required is None:
         application_required = org.default_application_required
 
-    participation_type = org.default_participation_type
+    participation_type = (
+        event_participation_type
+        if event_participation_type is not None
+        else org.default_participation_type
+    )
     if (
         application_required is True
         and participation_type
@@ -288,6 +294,7 @@ def normalize_events(
             org=org,
             note=raw.note,
             title=raw.title,
+            event_participation_type=raw.participation_type,
         )
 
         service_events.append(

--- a/kendo_keiko/scrapers/__init__.py
+++ b/kendo_keiko/scrapers/__init__.py
@@ -8,6 +8,7 @@ from kendo_keiko.scrapers.kenbokukai import scrape as scrape_kenbokukai
 from kendo_keiko.scrapers.kenkyukai import scrape as scrape_kenkyukai
 from kendo_keiko.scrapers.kent import scrape as scrape_kent
 from kendo_keiko.scrapers.kanagawa import scrape as scrape_kanagawa
+from kendo_keiko.scrapers.saitama import scrape as scrape_saitama
 from kendo_keiko.scrapers.tokyo import scrape as scrape_tokyo
 
 
@@ -21,6 +22,7 @@ SCRAPER_REGISTRY: dict[str, Scraper] = {
     "ajkf": scrape_ajkf,
     "kent": scrape_kent,
     "kanagawa": scrape_kanagawa,
+    "saitama": scrape_saitama,
     "kenkyukai": scrape_kenkyukai,
     "kenbokukai": scrape_kenbokukai,
     "tokyo": scrape_tokyo,

--- a/kendo_keiko/scrapers/saitama.py
+++ b/kendo_keiko/scrapers/saitama.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+import datetime as dt
+import re
+import sys
+import unicodedata
+from typing import Optional
+from urllib.parse import urljoin, urlparse
+
+import requests
+from bs4 import BeautifulSoup
+
+from kendo_keiko.models import (
+    Organization,
+    ParticipationType,
+    RawScrapedEvent,
+)
+from kendo_keiko.scrapers.common import HEADERS, JST
+
+
+SAITAMA_BASE_URL = "https://www.saitama-kendo.or.jp"
+CALENDAR_PLUGIN_ID = 11
+CALENDAR_FRAME_ID = 229
+MONTHS_TO_SCAN = 13
+
+MONTH_URL = (
+    f"{SAITAMA_BASE_URL}/plugin/calendars/index/"
+    f"{CALENDAR_PLUGIN_ID}/{CALENDAR_FRAME_ID}"
+)
+
+EVENT_PATH_RE = re.compile(
+    r"^/plugin/calendars/show/"
+    rf"{CALENDAR_PLUGIN_ID}/\d+/(?P<event_id>\d+)/?$"
+)
+
+TARGET_TITLE_KEYS = frozenset(
+    {
+        "月例稽古",
+        "月例稽古会",
+        "追加月例稽古会",
+    }
+)
+REGULAR_TITLE_KEYS = frozenset(
+    {
+        "月例稽古",
+        "月例稽古会",
+    }
+)
+
+WEEKDAYS_JA = ["月", "火", "水", "木", "金", "土", "日"]
+
+FISCAL_2026_START = dt.date(2026, 4, 1)
+FISCAL_2026_END = dt.date(2027, 3, 31)
+
+
+def _debug_print(enabled: bool, message: str) -> None:
+    if enabled:
+        print(f"[DEBUG] {message}", file=sys.stderr)
+
+
+def normalize_text(value: str) -> str:
+    normalized = unicodedata.normalize("NFKC", value)
+    return re.sub(r"\s+", " ", normalized).strip()
+
+
+def normalize_title_key(value: str) -> str:
+    return re.sub(r"\s+", "", unicodedata.normalize("NFKC", value))
+
+
+def is_target_title(value: str) -> bool:
+    return normalize_title_key(value) in TARGET_TITLE_KEYS
+
+
+def build_month_url(year: int, month: int) -> str:
+    if not 1 <= month <= 12:
+        raise ValueError(f"invalid month: {month}")
+
+    return (
+        f"{MONTH_URL}?year{CALENDAR_FRAME_ID}={year:04d}"
+        f"&month{CALENDAR_FRAME_ID}={month:02d}"
+    )
+
+
+def iter_months(
+    start_date: dt.date,
+    count: int = MONTHS_TO_SCAN,
+) -> list[tuple[int, int]]:
+    if count < 1:
+        raise ValueError("count must be at least 1")
+
+    start_index = start_date.year * 12 + start_date.month - 1
+    result: list[tuple[int, int]] = []
+
+    for offset in range(count):
+        value = start_index + offset
+        year, zero_based_month = divmod(value, 12)
+        result.append((year, zero_based_month + 1))
+
+    return result
+
+
+def normalize_event_url(url: str) -> str:
+    absolute_url = urljoin(SAITAMA_BASE_URL, url)
+    parsed = urlparse(absolute_url)
+
+    if parsed.netloc not in {
+        "www.saitama-kendo.or.jp",
+        "saitama-kendo.or.jp",
+    }:
+        raise ValueError(f"unexpected Saitama event host: {parsed.netloc}")
+
+    match = EVENT_PATH_RE.match(parsed.path)
+    if not match:
+        raise ValueError(f"unexpected Saitama event URL: {url}")
+
+    event_id = match.group("event_id")
+    return (
+        f"{SAITAMA_BASE_URL}/plugin/calendars/show/"
+        f"{CALENDAR_PLUGIN_ID}/{CALENDAR_FRAME_ID}/{event_id}"
+    )
+
+
+def extract_monthly_practice_links(html: str) -> list[str]:
+    soup = BeautifulSoup(html, "html.parser")
+    frame = soup.find(id=f"frame-card-{CALENDAR_FRAME_ID}")
+
+    if frame is None:
+        raise ValueError(
+            "埼玉県剣道連盟の主カレンダーframeが見つかりません"
+        )
+
+    links: set[str] = set()
+
+    for anchor in frame.select('a[href*="/plugin/calendars/show/"]'):
+        label = normalize_text(anchor.get_text(" ", strip=True))
+        if not is_target_title(label):
+            continue
+
+        href = anchor.get("href")
+        if not href:
+            continue
+
+        links.add(normalize_event_url(href))
+
+    return sorted(links)
+
+
+def extract_detail_fields(html: str) -> dict[str, str]:
+    soup = BeautifulSoup(html, "html.parser")
+
+    for detail_list in soup.find_all("dl"):
+        fields: dict[str, str] = {}
+
+        for term in detail_list.find_all("dt", recursive=False):
+            description = term.find_next_sibling("dd")
+            if description is None:
+                continue
+
+            key = normalize_text(term.get_text(" ", strip=True))
+            value = normalize_text(description.get_text(" ", strip=True))
+            fields[key] = value
+
+        title = fields.get("タイトル", "")
+        if title and is_target_title(title):
+            return fields
+
+    return {}
+
+
+def parse_datetime(value: str, field_name: str) -> dt.datetime:
+    normalized = normalize_text(value)
+
+    try:
+        return dt.datetime.strptime(normalized, "%Y-%m-%d %H:%M")
+    except ValueError as exc:
+        raise ValueError(
+            f"埼玉県剣道連盟の{field_name}を解析できません: {value!r}"
+        ) from exc
+
+
+def is_regular_repro_event(
+    *,
+    title: str,
+    venue: Optional[str],
+    event_date: dt.date,
+) -> bool:
+    return (
+        normalize_title_key(title) in REGULAR_TITLE_KEYS
+        and venue is not None
+        and "リプロ武道館" in normalize_text(venue)
+        and FISCAL_2026_START <= event_date <= FISCAL_2026_END
+    )
+
+
+def build_note(
+    *,
+    regular_repro_event: bool,
+) -> str:
+    if regular_repro_event:
+        return (
+            "参加費: 無料\n"
+            "対象: 中学生以上の剣道経験者\n"
+            "埼玉県立武道館の令和8年度月例稽古年間予定表に"
+            "基づく情報です。\n"
+            "日程や参加条件が変更される場合があります。"
+            "参加前に公式情報をご確認ください。"
+        )
+
+    return (
+        "埼玉県剣道連盟の公式カレンダーをもとに掲載しています。"
+        "参加条件、申込要否、参加費は公式情報をご確認ください。"
+    )
+
+
+def parse_event_detail(
+    *,
+    html: str,
+    source_url: str,
+    organization: Organization,
+) -> Optional[RawScrapedEvent]:
+    fields = extract_detail_fields(html)
+    if not fields:
+        return None
+
+    title = fields["タイトル"]
+    if not is_target_title(title):
+        return None
+
+    start_value = fields.get("開始日時")
+    if not start_value:
+        raise ValueError(
+            "埼玉県剣道連盟の月例稽古会に開始日時がありません"
+        )
+
+    start = parse_datetime(start_value, "開始日時")
+
+    end_value = fields.get("終了日時")
+    end = (
+        parse_datetime(end_value, "終了日時")
+        if end_value
+        else None
+    )
+
+    venue = fields.get("場所") or None
+    event_date = start.date()
+    regular_repro_event = is_regular_repro_event(
+        title=title,
+        venue=venue,
+        event_date=event_date,
+    )
+    participation_type: ParticipationType = (
+        "anyone" if regular_repro_event else "unknown"
+    )
+
+    return RawScrapedEvent(
+        group=organization.name,
+        title=title,
+        date=event_date.isoformat(),
+        weekday=WEEKDAYS_JA[event_date.weekday()],
+        start_time=start.strftime("%H:%M"),
+        end_time=end.strftime("%H:%M") if end else None,
+        venue=venue,
+        area=organization.area,
+        access=None,
+        note=build_note(
+            regular_repro_event=regular_repro_event,
+        ),
+        source_url=normalize_event_url(source_url),
+        event_type=organization.event_type,
+        participation_type=participation_type,
+    )
+
+
+def fetch_html(url: str, timeout: int = 30) -> str:
+    response = requests.get(
+        url,
+        headers=HEADERS,
+        timeout=timeout,
+    )
+    response.raise_for_status()
+    response.encoding = response.apparent_encoding or response.encoding
+    return response.text
+
+
+def scrape(
+    organization: Organization,
+    debug: bool = False,
+) -> list[RawScrapedEvent]:
+    today = dt.datetime.now(JST).date()
+    event_links: set[str] = set()
+
+    for year, month in iter_months(today):
+        month_url = build_month_url(year, month)
+        _debug_print(debug, f"Saitama calendar month: {month_url}")
+        month_html = fetch_html(month_url)
+        event_links.update(extract_monthly_practice_links(month_html))
+
+    events: list[RawScrapedEvent] = []
+
+    for event_url in sorted(event_links):
+        _debug_print(debug, f"Saitama event detail: {event_url}")
+        event_html = fetch_html(event_url)
+        event = parse_event_detail(
+            html=event_html,
+            source_url=event_url,
+            organization=organization,
+        )
+        if event is not None:
+            events.append(event)
+
+    _debug_print(
+        debug,
+        f"Saitama links={len(event_links)} events={len(events)}",
+    )
+
+    return sorted(
+        events,
+        key=lambda event: (
+            event.date,
+            event.start_time or "",
+            event.title or "",
+        ),
+    )

--- a/public/index.html
+++ b/public/index.html
@@ -882,6 +882,12 @@
           <p class="organization-link"><a href="https://kanagawa-kenren.com/taikai_cal/calender" target="_blank" rel="noopener noreferrer">公式サイトを確認</a></p>
         </li>
         <li class="organization-item">
+          <h3>埼玉県剣道連盟</h3>
+          <p class="organization-area">主な地域: 埼玉県</p>
+          <p>埼玉県剣道連盟が埼玉県内で開催する月例稽古会の予定を掲載しています。</p>
+          <p class="organization-link"><a href="https://www.saitama-kendo.or.jp/plugin/calendars/index/11/229" target="_blank" rel="noopener noreferrer">公式サイトを確認</a></p>
+        </li>
+        <li class="organization-item">
           <h3>眞心会</h3>
           <p class="organization-area">主な地域: 埼玉県</p>
           <p>さいたま市見沼区の春里中学校武道場で開催される眞心会の稽古予定を掲載しています。</p>

--- a/scripts/build_lambda.sh
+++ b/scripts/build_lambda.sh
@@ -83,6 +83,7 @@ import scraper_worker_handler
 from kendo_keiko.manual_events import load_manual_events
 from kendo_keiko.models import RawScrapedEvent, ScrapeResult
 from kendo_keiko.scrapers.ajkf import scrape
+from kendo_keiko.scrapers.saitama import scrape as scrape_saitama
 
 print("[INFO] Lambda package imports: OK")
 PY
@@ -127,6 +128,7 @@ required_files=(
   "kendo_keiko/scrapers/common.py"
   "kendo_keiko/scrapers/kent.py"
   "kendo_keiko/scrapers/kanagawa.py"
+  "kendo_keiko/scrapers/saitama.py"
   "kendo_keiko/scrapers/kenkyukai.py"
   "kendo_keiko/scrapers/kenbokukai.py"
   "kendo_keiko/scrapers/tokyo.py"

--- a/tests/fixtures/saitama_additional_event.html
+++ b/tests/fixtures/saitama_additional_event.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="ja">
+  <body>
+    <dl class="row">
+      <dt>タイトル</dt>
+      <dd>追加 月例稽古会</dd>
+      <dt>全日予定</dt>
+      <dd>OFF</dd>
+      <dt>開始日時</dt>
+      <dd>2026-10-22 19:00</dd>
+      <dt>終了日時</dt>
+      <dd>2026-10-22 20:00</dd>
+      <dt>場所</dt>
+      <dd>ぐるる宮代</dd>
+      <dt>連絡先</dt>
+      <dd></dd>
+      <dt>本文</dt>
+      <dd></dd>
+    </dl>
+  </body>
+</html>

--- a/tests/fixtures/saitama_october_calendar.html
+++ b/tests/fixtures/saitama_october_calendar.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="ja">
+  <body>
+    <div id="frame-card-229">
+      <div id="collapse-229-2026-10-01">
+        <a href="https://www.saitama-kendo.or.jp/plugin/calendars/show/11/229/2624#frame-229">
+          月例稽古会
+        </a>
+      </div>
+      <div id="collapse-229-2026-10-11">
+        <a href="https://www.saitama-kendo.or.jp/plugin/calendars/show/11/229/2600#frame-229">
+          剣道七段審査会
+        </a>
+      </div>
+      <div id="collapse-229-2026-10-22">
+        <a href="https://www.saitama-kendo.or.jp/plugin/calendars/show/11/229/2627#frame-229">
+          追加 月例稽古会
+        </a>
+      </div>
+    </div>
+    <div id="frame-card-22">
+      <a href="https://www.saitama-kendo.or.jp/plugin/calendars/show/11/22/2554#frame-22">
+        月例稽古
+      </a>
+    </div>
+  </body>
+</html>

--- a/tests/fixtures/saitama_regular_event.html
+++ b/tests/fixtures/saitama_regular_event.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="ja">
+  <body>
+    <dl class="row">
+      <dt>タイトル</dt>
+      <dd>月例稽古</dd>
+      <dt>全日予定</dt>
+      <dd>OFF</dd>
+      <dt>開始日時</dt>
+      <dd>2026-08-06 19:00</dd>
+      <dt>終了日時</dt>
+      <dd>2026-08-06 20:00</dd>
+      <dt>場所</dt>
+      <dd>リプロ武道館 主道場</dd>
+      <dt>連絡先</dt>
+      <dd></dd>
+      <dt>本文</dt>
+      <dd></dd>
+    </dl>
+  </body>
+</html>

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -144,6 +144,45 @@ class PipelineTests(unittest.TestCase):
         self.assertFalse(event.application_required)
         self.assertIsNone(event.verified_at)
 
+    def test_event_participation_type_overrides_organization_default(
+        self,
+    ) -> None:
+        organization = Organization(
+            organization_id="event-override-org",
+            name="イベント個別条件団体",
+            area="埼玉県",
+            website_url="https://example.com/",
+            source_type="official_site",
+            scraper_type="test-scraper",
+            scraper_enabled=True,
+            event_type="federation_keiko",
+            default_participation_type="unknown",
+        )
+        raw_event = RawScrapedEvent(
+            group=organization.name,
+            title="月例稽古",
+            date="2026-08-06",
+            weekday="木",
+            start_time="19:00",
+            end_time="20:00",
+            venue="テスト武道館",
+            area=None,
+            access=None,
+            note="参加費: 無料",
+            source_url="https://example.com/event",
+            event_type="federation_keiko",
+            participation_type="anyone",
+        )
+
+        event = normalize_events(
+            [raw_event],
+            [organization],
+            "2026-08-06T06:00:00+09:00",
+        )[0]
+
+        self.assertEqual("anyone", event.participation_type)
+        self.assertIsNone(event.application_required)
+
     def test_event_application_text_overrides_organization_default(
         self,
     ) -> None:

--- a/tests/test_saitama_scraper.py
+++ b/tests/test_saitama_scraper.py
@@ -1,0 +1,140 @@
+import unittest
+from pathlib import Path
+
+from kendo_keiko.models import Organization
+from kendo_keiko.scrapers.saitama import (
+    build_month_url,
+    extract_monthly_practice_links,
+    normalize_event_url,
+    parse_event_detail,
+)
+
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+class SaitamaScraperTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.organization = Organization(
+            organization_id="saitama",
+            name="埼玉県剣道連盟",
+            area="埼玉県",
+            website_url=(
+                "https://www.saitama-kendo.or.jp/"
+                "plugin/calendars/index/11/229"
+            ),
+            source_type="official_site",
+            scraper_type="saitama",
+            scraper_enabled=True,
+            event_type="federation_keiko",
+        )
+
+    def test_builds_month_url(self) -> None:
+        self.assertEqual(
+            "https://www.saitama-kendo.or.jp/"
+            "plugin/calendars/index/11/229"
+            "?year229=2026&month229=10",
+            build_month_url(2026, 10),
+        )
+
+    def test_collects_only_target_links_from_primary_frame(self) -> None:
+        html = (
+            FIXTURE_DIR / "saitama_october_calendar.html"
+        ).read_text(encoding="utf-8")
+
+        self.assertEqual(
+            [
+                "https://www.saitama-kendo.or.jp/"
+                "plugin/calendars/show/11/229/2624",
+                "https://www.saitama-kendo.or.jp/"
+                "plugin/calendars/show/11/229/2627",
+            ],
+            extract_monthly_practice_links(html),
+        )
+
+    def test_normalizes_frame_query_and_fragment(self) -> None:
+        self.assertEqual(
+            "https://www.saitama-kendo.or.jp/"
+            "plugin/calendars/show/11/229/2627",
+            normalize_event_url(
+                "https://www.saitama-kendo.or.jp/"
+                "plugin/calendars/show/11/22/2627"
+                "?frame=22#frame-22"
+            ),
+        )
+
+    def test_parses_regular_monthly_practice(self) -> None:
+        html = (
+            FIXTURE_DIR / "saitama_regular_event.html"
+        ).read_text(encoding="utf-8")
+
+        event = parse_event_detail(
+            html=html,
+            source_url=(
+                "https://www.saitama-kendo.or.jp/"
+                "plugin/calendars/show/11/229/2554#frame-229"
+            ),
+            organization=self.organization,
+        )
+
+        self.assertIsNotNone(event)
+        assert event is not None
+        self.assertEqual("月例稽古", event.title)
+        self.assertEqual("2026-08-06", event.date)
+        self.assertEqual("木", event.weekday)
+        self.assertEqual("19:00", event.start_time)
+        self.assertEqual("20:00", event.end_time)
+        self.assertEqual("リプロ武道館 主道場", event.venue)
+        self.assertEqual("anyone", event.participation_type)
+        self.assertIn("参加費: 無料", event.note or "")
+        self.assertIn("中学生以上", event.note or "")
+
+    def test_parses_additional_event_without_regular_conditions(self) -> None:
+        html = (
+            FIXTURE_DIR / "saitama_additional_event.html"
+        ).read_text(encoding="utf-8")
+
+        event = parse_event_detail(
+            html=html,
+            source_url=(
+                "https://www.saitama-kendo.or.jp/"
+                "plugin/calendars/show/11/22/2627?frame=22"
+            ),
+            organization=self.organization,
+        )
+
+        self.assertIsNotNone(event)
+        assert event is not None
+        self.assertEqual("追加 月例稽古会", event.title)
+        self.assertEqual("2026-10-22", event.date)
+        self.assertEqual("19:00", event.start_time)
+        self.assertEqual("20:00", event.end_time)
+        self.assertEqual("ぐるる宮代", event.venue)
+        self.assertEqual("unknown", event.participation_type)
+        self.assertNotIn("参加費: 無料", event.note or "")
+        self.assertIn("参加条件", event.note or "")
+
+    def test_ignores_unrelated_event_detail(self) -> None:
+        html = """
+        <dl class="row">
+          <dt>タイトル</dt><dd>剣道七段審査会</dd>
+          <dt>開始日時</dt><dd>2026-10-11 09:00</dd>
+          <dt>終了日時</dt><dd>2026-10-11 17:00</dd>
+          <dt>場所</dt><dd>リプロ武道館</dd>
+        </dl>
+        """
+
+        self.assertIsNone(
+            parse_event_detail(
+                html=html,
+                source_url=(
+                    "https://www.saitama-kendo.or.jp/"
+                    "plugin/calendars/show/11/229/2600"
+                ),
+                organization=self.organization,
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scraper_registry.py
+++ b/tests/test_scraper_registry.py
@@ -33,6 +33,7 @@ class ScraperRegistryTests(unittest.TestCase):
                 "kent",
                 "kenkyukai",
                 "kenbokukai",
+                "saitama",
                 "tokyo",
             },
             set(SCRAPER_REGISTRY),


### PR DESCRIPTION
## 概要

埼玉県剣道連盟の公式カレンダーから、月例稽古会を自動取得するスクレイパーを追加します。

Closes #57

## 実装内容

- 埼玉県剣道連盟スクレイパーを追加
- 現在月から13か月分の公式カレンダーを探索
- 月例稽古関連イベントのみを完全一致で取得
- 大会、審査会、講習会などは対象外
- 詳細ページから開始日時、終了日時、会場を取得
- カレンダーイベントIDを使ってURLを正規化
- `SCRAPER_REGISTRY`へ`saitama`を登録
- 埼玉県剣道連盟を自動取得団体として登録
- 掲載団体セクションを再生成
- Lambdaビルド対象とZIP検証対象へ追加

## 参加条件の扱い

リプロ武道館で開催される令和8年度の通常月例稽古については、埼玉県立武道館の年間予定表を根拠として次を設定します。

- 参加費: 無料
- 対象: 中学生以上の剣道経験者
- participation_type: anyone
- application_required: unknown

ぐるる宮代で開催される追加月例稽古については、通常月例の条件を流用せず、次のとおり扱います。

- participation_type: unknown
- application_required: unknown
- 参加費: 未設定

## 取得確認

実サイトから次の4件を取得できることを確認しました。

- 2026-08-06 月例稽古
- 2026-09-03 月例稽古
- 2026-10-01 月例稽古会
- 2026-10-22 追加 月例稽古会

公式カレンダーに未掲載の日程は推測で生成しません。

## テスト

- 埼玉スクレイパーテスト: 6件成功
- 全テスト: 81件成功
- `git diff --check`: 成功
- Lambda ZIP内のスクレイパー、レジストリ、団体設定を確認
- ZIP内コードによる実サイト取得: 4件成功
- 実サイト取得時間: 約4.9秒
